### PR TITLE
Fix I2C driver hanging/BSOD'ing on a lot of transactions

### DIFF
--- a/drivers/i2c/rk3xi2c/driver.h
+++ b/drivers/i2c/rk3xi2c/driver.h
@@ -134,6 +134,8 @@ UINT32 read32(PRK3XI2C_CONTEXT pDevice, UINT32 reg);
 void write32(PRK3XI2C_CONTEXT pDevice, UINT32 reg, UINT32 val);
 
 BOOLEAN rk3x_i2c_irq(WDFINTERRUPT Interrupt, ULONG MessageID);
+void rk3x_i2c_dpc(WDFINTERRUPT Interrupt, WDFOBJECT AssociatedObject);
+
 NTSTATUS i2c_xfer(PRK3XI2C_CONTEXT pDevice,
     _In_ SPBTARGET SpbTarget,
     _In_ SPBREQUEST SpbRequest,

--- a/drivers/i2c/rk3xi2c/rk3xi2c.c
+++ b/drivers/i2c/rk3xi2c/rk3xi2c.c
@@ -490,7 +490,7 @@ IN PWDFDEVICE_INIT DeviceInit
 	WDF_INTERRUPT_CONFIG_INIT(
 		&interruptConfig,
 		rk3x_i2c_irq,
-		NULL);
+		rk3x_i2c_dpc);
 
 	status = WdfInterruptCreate(
 		device,

--- a/drivers/i2c/rk3xi2c/rk3xi2c.inx
+++ b/drivers/i2c/rk3xi2c/rk3xi2c.inx
@@ -6,7 +6,7 @@
 ;    rk3xi2c.inf
 ;
 ;Abstract:
-;    INF file for installing the RockChip I2C Controller Driver
+;    INF file for installing the Rockchip I2C Controller Driver
 ;
 ;
 ;--*/
@@ -72,6 +72,6 @@ LoadOrderGroup = Base
 [Strings]
 SPSVCINST_ASSOCSERVICE= 0x00000002
 StdMfg                 = "Rockchip"
-DiskId1                = "RockChip I2C Controller Installation Disk #1"
-Rk3xI2C.DeviceDesc = "RockChip I2C Controller"
-Rk3xI2C.SVCDESC    = "RockChip I2C Controller Service"
+DiskId1                = "Rockchip I2C Controller Installation Disk #1"
+Rk3xI2C.DeviceDesc = "Rockchip I2C Controller"
+Rk3xI2C.SVCDESC    = "Rockchip I2C Controller Service"


### PR DESCRIPTION
KeSetEvent can't be called from an IRQ or it can eventually lead to a watchdog timeout. Create a DPC and call it from there instead