### PR TITLE
dwcsdhc - Remove BasicDriverOk from INF

### DIFF
--- a/drivers/sd/dwcsdhc/dwcsdhc.inx
+++ b/drivers/sd/dwcsdhc/dwcsdhc.inx
@@ -31,7 +31,6 @@ dwcsdhc.sys = 1
 %RKCP%=RKCP,NT$ARCH$
 
 [ControlFlags]
-BasicDriverOk=*
 ExcludeFromSelect=*
 
 ;


### PR DESCRIPTION
On latest WDK, INX files with BasicDriverOk fail to verify:

`error 1208: Directive 'BasicDriverOk' not allowed.`

A bit of research indicates that BasicDriverOk was removed from all driver samples back in March with comment "BasicDriverOk should only be used in a subset of inbox INFs":
https://github.com/microsoft/Windows-driver-samples/pull/908

A bit more research hints that this flag is used only as a hint for Windows Update behavior, something along the lines of "this is a generic driver but that's ok so don't look for a vendor-specific driver to replace it".