### PR TITLE
dwcsdhc - fix POOL_ZERO_DOWN_LEVEL_SUPPORT

### DIFF
--- a/drivers/sd/dwcsdhc/precomp.h
+++ b/drivers/sd/dwcsdhc/precomp.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
+
 #include <Ntddk.h>
 
 extern "C" {
@@ -21,5 +23,3 @@ extern "C" {
 
 #define INIT_SEGMENT_END \
     __pragma(code_seg(pop))
-
-#define POOL_ZERO_DOWN_LEVEL_SUPPORT


### PR DESCRIPTION
The `POOL_ZERO_DOWN_LEVEL_SUPPORT` macro only works if it is set before including `<ntddk.h>`, so move it up.