### PR TITLE
gmac - fix hang in Ethernet driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository contains drivers for RK35xx-based platforms, with a focus on RK3
 |Multimedia codecs||🔴 Not working||
 |DSI||🔴 Not working||
 |CSI||🔴 Not working||
-|GMAC Ethernet|[dwc_eqos](tree/master/drivers/net/dwc_eqos)|🟡 Partially working|1000Mbps only (gigabit Ethernet only - 10/100 not yet supported)|
+|GMAC Ethernet|[dwc_eqos](drivers/net/dwc_eqos)|🟡 Partially working|1000Mbps only (gigabit Ethernet only - 10/100 not yet supported)|
 |UART||🔴 Not working|No OS driver but debugging does work on UART2, being configured by UEFI.|
 |GPIO|[rk3xgpio](https://github.com/worproject/Rockchip-Windows-Drivers/tree/master/drivers/gpio)|🟢 Working||
 |I2C|[rk3xi2c](https://github.com/worproject/Rockchip-Windows-Drivers/tree/master/drivers/i2c)|🟢 Working||

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository contains drivers for RK35xx-based platforms, with a focus on RK3
 |Multimedia codecs||🔴 Not working||
 |DSI||🔴 Not working||
 |CSI||🔴 Not working||
-|GMAC Ethernet|[dwc_eqos](https://github.com/worproject/Rockchip-Windows-Drivers/tree/master/drivers/net/dwc_eqos)|🟢 Working||
+|GMAC Ethernet|[dwc_eqos](tree/master/drivers/net/dwc_eqos)|🟡 Partially working|1000Mbps only (gigabit Ethernet only - 10/100 not yet supported)|
 |UART||🔴 Not working|No OS driver but debugging does work on UART2, being configured by UEFI.|
 |GPIO|[rk3xgpio](https://github.com/worproject/Rockchip-Windows-Drivers/tree/master/drivers/gpio)|🟢 Working||
 |I2C|[rk3xi2c](https://github.com/worproject/Rockchip-Windows-Drivers/tree/master/drivers/i2c)|🟢 Working||

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -1579,7 +1579,7 @@ struct MacRegisters
 
     // MTL_DBG_STS @ 0x0C0C = 0x1900000:
     // The FIFO Debug Status register contains the status of FIFO debug access.
-    ULONG MtlDdbSts;
+    ULONG MtlDebugStatus;
 
     // MTL_FIFO_Debug_Data @ 0x0C10 = 0x0:
     // The FIFO Debug Data register contains the data to be written to or read from

--- a/drivers/net/dwc_eqos/rxqueue.cpp
+++ b/drivers/net/dwc_eqos/rxqueue.cpp
@@ -203,7 +203,10 @@ RxQueueAdvance(_In_ NETPACKETQUEUE queue)
             queuedPkts += 1;
         }
 
-        if (descIndex != context->descEnd)
+        // In some error cases, the device may stall until we write to the tail pointer
+        // again. Write to the tail pointer if there are pending descriptors, even if we
+        // didn't fill any new ones.
+        if (descIndex != descNext)
         {
             SetDescEnd(context, descIndex);
             context->fragmentRing->NextIndex = fragIndex;

--- a/drivers/net/dwc_eqos/txqueue.cpp
+++ b/drivers/net/dwc_eqos/txqueue.cpp
@@ -304,7 +304,8 @@ TxQueueCancel(_In_ NETPACKETQUEUE queue)
     {
         // Wait for a potential in-progress packet to be sent.
 
-        for (retry = 0; retry != 10; retry += 1)
+        unsigned constexpr MaxRetry = 100;
+        for (retry = 0; retry != MaxRetry; retry += 1)
         {
             auto debug = Read32(&context->mtlRegs->TxDebug);
 
@@ -316,7 +317,7 @@ TxQueueCancel(_In_ NETPACKETQUEUE queue)
             KeStallExecutionProcessor(20);
         }
 
-        if (retry != 0)
+        if (retry != MaxRetry)
         {
             // Last chance for any packets to be reported as sent.
             mode = 1;


### PR DESCRIPTION
Ethernet driver is hanging. Occurs due to rollover of statistics, which triggers an interrupt, and we never clear the interrupt's status.

Quick fix is to just freeze the statistics, and then they never trigger interrupts.

Additional change: disable interrupts while the DPC is pending. This noticably improves performance.