### PR TITLE
dwc_eqos - cosmetics (comments, naming)

### DIFF
--- a/drivers/net/dwc_eqos/device.h
+++ b/drivers/net/dwc_eqos/device.h
@@ -1,15 +1,22 @@
+/*
+Device behavior. Includes adapter and interrupt since they are 1:1 with the device.
+*/
 #pragma once
 
+// Referenced in driver.cpp DriverEntry.
+// Called by WDF.
+__declspec(code_seg("PAGE"))
+EVT_WDF_DRIVER_DEVICE_ADD
+DeviceAdd;
+
+// Called by rxqueue.cpp RxQueueSetNotificationEnabled.
 void
 DeviceSetNotificationRxQueue(
     _In_ NETADAPTER adapter,
     _In_opt_ NETPACKETQUEUE rxQueue);
 
+// Called by txqueue.cpp TxQueueSetNotificationEnabled.
 void
 DeviceSetNotificationTxQueue(
     _In_ NETADAPTER adapter,
     _In_opt_ NETPACKETQUEUE txQueue);
-
-__declspec(code_seg("PAGE"))
-EVT_WDF_DRIVER_DEVICE_ADD
-DeviceAdd;

--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -1,5 +1,5 @@
 #include "precomp.h"
-#include "device.h"
+#include "device.h" // DeviceAdd
 #include "trace.h"
 
 /*
@@ -7,14 +7,14 @@ TODO list:
 - Support for 10/100 Mbps modes (requires ACPI support).
 - Use ACPI to get DMA configuration.
 - Jumbo frames.
-- Receive queue memory optimization.
-- Configuration.
+- Receive queue memory optimization?
+- Configuration in registry (e.g. flow control).
 - Checksum offload.
 - Tx segmentation offload.
 - Rx segmentation offload.
 - Wake-on-LAN.
 - ARP offload.
-- Multi-queue support.
+- Multi-queue support?
 */
 
 TRACELOGGING_DEFINE_PROVIDER(

--- a/drivers/net/dwc_eqos/queue_common.h
+++ b/drivers/net/dwc_eqos/queue_common.h
@@ -1,6 +1,9 @@
+/*
+Definitions shared between TxQueue and RxQueue.
+*/
 #pragma once
 
-UINT32 constexpr QueueDescriptorSize = 64;
+UINT32 constexpr QueueDescriptorSize = 64; // 64 == sizeof(TxDescriptor) == sizeof(RxDescriptor)
 UINT32 constexpr QueueDescriptorMinCount = PAGE_SIZE / QueueDescriptorSize;
 UINT32 constexpr QueueDescriptorMaxCount = 0x400;
 
@@ -8,13 +11,19 @@ bool constexpr QueueBurstLengthX8 = true;
 UINT32 constexpr QueueBurstLength = 64u / (QueueBurstLengthX8 ? 8 : 1); // TODO: load from ACPI?
 
 // Alignment is mainly to make sure the allocation does not cross a 4GB boundary,
-// but it also simplifies working with the addresses.
+// but it also simplifies the QueueDescriptorAddressToIndex implementation.
 auto const QueueDescriptorAlignment = QueueDescriptorMaxCount * QueueDescriptorSize;
 
+// Given the size of the fragment ring, return the number of descriptors to
+// allocate for the descriptor ring. This will be a power of 2 between
+// QueueDescriptorMinCount and QueueDescriptorMaxCount.
 _IRQL_requires_max_(PASSIVE_LEVEL)
 UINT32
 QueueDescriptorCount(UINT32 fragmentCount);
 
+// Given a Current_App_RxDesc or Current_App_TxDesc address, return the corresponding
+// index into the descriptor ring. Assumes that descriptor ring is aligned to
+// QueueDescriptorAlignment. descPhysical and descCount are for assertions.
 _IRQL_requires_max_(DISPATCH_LEVEL)
 UINT32
 QueueDescriptorAddressToIndex(UINT32 address, PHYSICAL_ADDRESS descPhysical, UINT32 descCount);

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -1,12 +1,18 @@
+/*
+Register and descriptor layout for the DesignWare EQOS Ethernet controller.
+*/
 #pragma once
+
 #pragma warning(push)
 #pragma warning(disable:4201) // nonstandard extension used: nameless struct/union
 
 #pragma region Read32/Write32
 
+// Prevents unwanted template type deduction.
 template<class T>
 struct TypeIdentity { using type = T; };
 
+// Type-preserving wrapper for READ_REGISTER_ULONG.
 template<class T>
 _IRQL_requires_max_(HIGH_LEVEL)
 static T FORCEINLINE
@@ -18,6 +24,7 @@ Read32(_In_ T const* reg)
     return reinterpret_cast<T const&>(val);
 }
 
+// Type-preserving wrapper for WRITE_REGISTER_ULONG.
 template<class T>
 _IRQL_requires_max_(HIGH_LEVEL)
 static void FORCEINLINE
@@ -152,100 +159,100 @@ struct ChannelRegisters
     // DMA_CHx_Control @ 0x00 = 0x0:
     // The register specifies the MSS value for segmentation, length to skip between
     // two descriptors, and 8xPBL mode.
-    ChannelDmaControl_t DmaControl;
+    ChannelDmaControl_t Control;
 
     // DMA_CHx_Tx_Control @ 0x04 = 0x0:
     // The register controls the Tx features such as PBL, TCP segmentation, and Tx
     // Channel weights.
-    ChannelTxControl_t TxControl;
+    ChannelTxControl_t Tx_Control;
 
     // DMA_CHx_Rx_Control @ 0x08 = 0x0:
     // The DMA Channel0 Receive Control register controls the Rx features such as PBL,
     // buffer size, and extended status.
-    ChannelRxControl_t RxControl;
+    ChannelRxControl_t Rx_Control;
 
     ULONG Padding0C[1];
 
     // DMA_CHx_TxDesc_List_Address_Hi @ 0x10 = 0x0:
-    ULONG TxDescListAddressHigh;
+    ULONG TxDesc_List_Address_Hi;
 
     // DMA_CHx_TxDesc_List_Address @ 0x14 = 0x0:
     // The Channel0 Tx Descriptor List Address register points the DMA to the start of
     // Transmit.
-    ULONG TxDescListAddress;
+    ULONG TxDesc_List_Address;
 
     // DMA_CHx_RxDesc_List_Address_Hi @ 0x18 = 0x0:
-    ULONG RxDescListAddressHigh;
+    ULONG RxDesc_List_Address_Hi;
 
     // DMA_CHx_RxDesc_List_Address @ 0x1C = 0x0:
     // The Channel0 Rx Descriptor List Address register points the DMA to the start of
     // Receive descriptor list.
-    ULONG RxDescListAddress;
+    ULONG RxDesc_List_Address;
 
     // DMA_CHx_TxDesc_Tail_Pointer @ 0x20 = 0x0:
     // The Channel0 Tx Descriptor Tail Pointer register points to an offset from the
     // base and indicates the location of the last valid descriptor.
-    ULONG TxDescTailPointer;
+    ULONG TxDesc_Tail_Pointer;
 
     ULONG Padding24[1];
 
     // DMA_CHx_RxDesc_Tail_Pointer @ 0x28 = 0x0:
     // The Channel0 Rx Descriptor Tail Pointer Points to an offset from the base and
     // indicates the location of the last valid descriptor.
-    ULONG RxDescTailPointer;
+    ULONG RxDesc_Tail_Pointer;
 
     // DMA_CHx_TxDesc_Ring_Length @ 0x2C = 0x0:
     // The Tx Descriptor Ring Length register contains the length of the Transmit
     // descriptor ring.
-    ULONG TxDescRingLength;
+    ULONG TxDesc_Ring_Length;
 
     // DMA_CHx_RxDesc_Ring_Length @ 0x30 = 0x0:
     // The Channel0 Rx Descriptor Ring Length register contains the length of the
     // Receive descriptor circular ring.
-    ULONG RxDescRingLength;
+    ULONG RxDesc_Ring_Length;
 
     // DMA_CHx_Interrupt_Enable @ 0x34 = 0x0:
     // The Channel0 Interrupt Enable register enables the interrupts reported by the
     // Status register.
-    ChannelInterruptEnable_t InterruptEnable;
+    ChannelInterruptEnable_t Interrupt_Enable;
 
     // DMA_CHx_Rx_Interrupt_WD_Timer @ 0x38 = 0x0:
     // The Receive Interrupt Watchdog Timer register indicates the watchdog timeout
     // for Receive Interrupt (RI) from the DMA.
-    ULONG RxInterruptWdTimer;
+    ULONG Rx_Interrupt_WD_Timer;
 
     // DMA_CHx_Slot_Func_Ctrl_Status @ 0x3C = 0x7C0:
     // The Slot Function Control and Status register contains the control bits for
     // slot function and the status for Transmit path.
-    ULONG SlotFuncCtrlStatus;
+    ULONG Slot_Func_Ctrl_Status;
 
     ULONG Padding40[1];
 
     // DMA_CHx_Current_App_TxDesc @ 0x44 = 0x0:
     // The Channel0 Current Application Transmit Descriptor register points to the
     // current Transmit descriptor read by the DMA.
-    ULONG TxCurrentAppDesc;
+    ULONG Current_App_TxDesc;
 
     ULONG Padding48[1];
 
     // DMA_CHx_Current_App_RxDesc @ 0x4C = 0x0:
     // The Channel0 Current Application Receive Descriptor register points to the
     // current Receive descriptor read by the DMA.
-    ULONG RxCurrentAppDesc;
+    ULONG Current_App_RxDesc;
 
     ULONG Padding50[1];
 
     // DMA_CHx_Current_App_TxBuffer @ 0x54 = 0x0:
     // The Channel0 Current Application Transmit Buffer Address register points to the
     // current Tx buffer address read by the DMA.
-    ULONG TxCurrentAppBuffer;
+    ULONG Current_App_TxBuffer;
 
     ULONG Padding58[1];
 
     // DMA_CHx_Current_App_RxBuffer @ 0x5C = 0x0:
     // The Channel0 Current Application Receive Buffer Address register points to the
     // current Rx buffer address read by the DMA.
-    ULONG RxCurrentAppBuffer;
+    ULONG Current_App_RxBuffer;
 
     // DMA_CHx_Status @ 0x60 = 0x0:
     // The software driver (application) reads the Status register during interrupt
@@ -256,12 +263,12 @@ struct ChannelRegisters
     // This register has the number of packet counter that got dropped by the DMA
     // either due to Bus Error or due to programming RPF field in RxControl
     // register.
-    ULONG MissFrameCnt;
+    ULONG Miss_Frame_Cnt;
 
     // DMA_CHx_RX_ERI_Cnt @ 0x68 = 0x0:
     // The RxEriCnt registers provides the count of the number of times ERI
     // was asserted.
-    ULONG RxEriCnt;
+    ULONG Rx_Eri_Cnt;
 
     ULONG Padding6C[5];
 };
@@ -344,59 +351,59 @@ struct MtlQueueRegisters
     // MTL_TxQx_Operation_Mode @ 0x00 = 0x60000:
     // The Queue X Transmit Operation Mode register establishes the Transmit queue
     // operating modes and commands.
-    MtlTxOperationMode_t TxOperationMode;
+    MtlTxOperationMode_t Tx_Operation_Mode;
 
     // MTL_TxQx_Underflow @ 0x04 = 0x0:
     // The Queue X Underflow Counter register contains the counter for packets aborted
     // because of Transmit queue underflow and packets missed because of Receive queue
     // packet flush.
-    ULONG TxUnderflow;
+    ULONG Tx_Underflow;
 
     // MTL_TxQx_Debug @ 0x08 = 0x0:
     // The Queue X Transmit Debug register gives the debug status of various blocks
     // related to the Transmit queue.
-    MtlTxDebug_t TxDebug;
+    MtlTxDebug_t Tx_Debug;
 
     ULONG Padding0C[2];
 
     // MTL_TxQx_ETS_Status @ 0x14 = 0x0:
     // The Queue X ETS Status register provides the average traffic transmitted in
     // Queue X.
-    ULONG TxEtsStatus;
+    ULONG Tx_Ets_Status;
 
     // MTL_TxQx_Quantum_Weight @ 0x18 = 0x0:
     // The Queue X Quantum or Weights register contains the quantum value for Deficit
     // Weighted Round Robin (DWRR), weights for the Weighted Round Robin (WRR), and
     // Weighted Fair Queuing (WFQ) for Queue X.
-    ULONG TxQuantumWeight;
+    ULONG Tx_Quantum_Weight;
 
     ULONG Padding1C[4];
 
     // MTL_Qx_Interrupt_Ctrl_Status @ 0x2C = 0x0:
     // This register contains the interrupt enable and status bits for the queue X
     // interrupts.
-    ULONG InterruptCtrlStatus;
+    ULONG Interrupt_Ctrl_Status;
 
     // MTL_RxQx_Operation_Mode @ 0x30 = 0x0:
     // The Queue X Receive Operation Mode register establishes the Receive queue
     // operating modes and command.
-    MtlRxOperationMode_t RxOperationMode;
+    MtlRxOperationMode_t Rx_Operation_Mode;
 
     // MTL_RxQx_Miss_Pkt_Ovf_Cnt @ 0x34 = 0x0:
     // The Queue X Missed Packet and Overflow Counter register contains the counter
     // for packets missed because of Receive queue packet flush and packets discarded
     // because of Receive queue overflow.
-    ULONG RxMissPktOvfCnt;
+    ULONG Rx_Miss_Pkt_Ovf_Cnt;
 
     // MTL_RxQx_Debug @ 0x38 = 0x0:
     // The Queue X Receive Debug register gives the debug status of various blocks
     // related to the Receive queue.
-    ULONG RxDebug;
+    ULONG Rx_Debug;
 
     // MTL_RxQx_Control @ 0x3C = 0x0:
     // The Queue Receive Control register controls the receive arbitration and passing
     // of received packets to the application.
-    ULONG RxControl;
+    ULONG Rx_Control;
 };
 static_assert(sizeof(MtlQueueRegisters) == 64);
 
@@ -458,14 +465,14 @@ struct MacL3L4Registers
     // MAC_L3_L4_ControlX @ 0x00 = 0x0:
     // The Layer 3 and Layer 4 Control register controls the operations of filter X of
     // Layer 3 and Layer 4.
-    ULONG Control;
+    ULONG L3_L4_Control;
 
     // MAC_Layer4_AddressX @ 0x04 = 0x0:
     // The MAC_Layer4_Address, MAC_L3_L4_Control, MAC_Layer3_Addr0_Reg,
     // MAC_Layer3_Addr1_Reg, MAC_Layer3_Addr2_Reg and MAC_Layer3_Addr3_Reg
     // registers are reserved (RO with default value) if Enable Layer 3 and Layer 4
     // Packet Filter option is not selected while configuring the core.
-    ULONG Layer4Address;
+    ULONG Layer4_Address;
 
     ULONG Padding08[2];
 
@@ -473,25 +480,25 @@ struct MacL3L4Registers
     // For IPv4 packets, the Layer 3 Address 0 Register contains the 32-bit
     // IP Source Address field. For IPv6 packets, it contains Bits[31:0] of the
     // 128-bit IP Source Address or Destination Address field.
-    ULONG Layer3Addr0;
+    ULONG Layer3_Addr0_Reg;
 
-    // MAC_Layer3_Addr1_Reg @ 0x14 = 0x0:
+    // MAC_Layer3_Addr1_RegX @ 0x14 = 0x0:
     // For IPv4 packets, the Layer 3 Address 1 Register contains the 32-bit
     // IP Destination Address field. For IPv6 packets, it contains Bits[63:32] of the
     // 128-bit IP Source Address or Destination Address field.
-    ULONG Layer3Addr1;
+    ULONG Layer3_Addr1_Reg;
 
-    // MAC_Layer3_Addr2_Reg @ 0x18 = 0x0:
+    // MAC_Layer3_Addr2_RegX @ 0x18 = 0x0:
     // The Layer 3 Address 2 Register is reserved for IPv4 packets. For
     // IPv6 packets, it contains Bits[95:64] of 128-bit IP Source Address or
     // Destination Address field.
-    ULONG Layer3Addr2;
+    ULONG Layer3_Addr2_Reg;
 
-    // MAC_Layer3_Addr3_Reg @ 0x1C = 0x0:
+    // MAC_Layer3_Addr3_RegX @ 0x1C = 0x0:
     // The Layer 3 Address 3 Register is reserved for IPv4 packets. For
     // IPv6 packets, it contains Bits[127:96] of 128-bit IP Source Address or
     // Destination Address field.
-    ULONG Layer3Addr3;
+    ULONG Layer3_Addr3_Reg;
 
     ULONG Padding20[4];
 };
@@ -893,26 +900,26 @@ struct MacRegisters
 {
     // MAC_Configuration @ 0x0000 = 0x0:
     // The MAC Configuration Register establishes the operating mode of the MAC.
-    MacConfiguration_t MacConfiguration;
+    MacConfiguration_t Mac_Configuration;
 
     // MAC_Ext_Configuration @ 0x0004 = 0x0:
     // The MAC Extended Configuration Register establishes the operating mode of the
     // MAC.
-    MacExtConfiguration_t MacExtConfiguration;
+    MacExtConfiguration_t Mac_Ext_Configuration;
 
     // MAC_Packet_Filter @ 0x0008 = 0x0:
     // The MAC Packet Filter register contains the filter controls for receiving
     // packets.
-    MacPacketFilter_t MacPacketFilter;
+    MacPacketFilter_t Mac_Packet_Filter;
 
     // MAC_Watchdog_Timeout @ 0x000C = 0x0:
     // The Watchdog Timeout register controls the watchdog timeout for received
     // packets.
-    ULONG MacWatchdogTimeout;
+    ULONG Mac_Watchdog_Timeout;
 
     // MAC_Hash_Table_RegX @ 0x0010 = 0x0:
     // The Hash Table Register X contains the Xth 32 bits of the hash table.
-    ULONG MacHashTable[3];
+    ULONG MAC_Hash_Table_Reg[3];
 
     ULONG Padding001C[13];
 
@@ -920,19 +927,19 @@ struct MacRegisters
     // This register is the redefined format of the MAC VLAN Tag Register. It is used
     // for indirect addressing. It contains the address offset, command type and Busy
     // Bit for CSR access of the Per VLAN Tag registers.
-    ULONG MacVlanTagCtrl;
+    ULONG Mac_Vlan_Tag_Ctrl;
 
     // MAC_VLAN_Tag_Data @ 0x0054 = 0x0:
     // This register holds the read/write data for Indirect Access of the Per VLAN Tag
     // registers.During the read access, this field contains valid read data only
     // after the OB bit is reset. During the write access, this field should be valid
     // prior to setting the OB bit in the MacVlanTag_Ctrl Register.
-    ULONG MacVlanTagData;
+    ULONG Mac_Vlan_Tag_Data;
 
     // MAC_VLAN_Hash_Table @ 0x0058 = 0x0:
     // When VTHM bit of the MacVlanTag register is set, the 16-bit VLAN Hash Table
     // register is used for group address filtering based on the VLAN tag.
-    ULONG MacVlanHashTable;
+    ULONG Mac_Vlan_Hash_Table;
 
     ULONG Padding005C[1];
 
@@ -940,78 +947,78 @@ struct MacRegisters
     // The VLAN Tag Inclusion or Replacement register contains the VLAN tag for
     // insertion or replacement in the Transmit packets. It also contains the VLAN tag
     // insertion controls.
-    ULONG MacVlanIncl;
+    ULONG Mac_Vlan_Incl;
 
     // MAC_Inner_VLAN_Incl @ 0x0064 = 0x0:
     // The Inner VLAN Tag Inclusion or Replacement register contains the inner VLAN
     // tag to be inserted or replaced in the Transmit packet. It also contains the
     // inner VLAN tag insertion controls.
-    ULONG MacInner_VlanIncl;
+    ULONG Mac_Inner_Vlan_Incl;
 
     ULONG Padding0068[2];
 
     // MAC_Q0_Tx_Flow_Ctrl @ 0x0070 = 0x0:
     // The Flow Control register controls the generation and reception of the Control
     // (Pause Command) packets by the Flow control module of the MAC.
-    MacTxFlowCtrl_t MacTxFlowCtrl;
+    MacTxFlowCtrl_t Mac_Tx_Flow_Ctrl;
 
     ULONG Padding0074[7];
 
     // MAC_Rx_Flow_Ctrl @ 0x0090 = 0x0:
     // The Receive Flow Control register controls the pausing of MAC Transmit based on
     // the received Pause packet.
-    ULONG MacRxFlowCtrl;
+    ULONG Mac_Rx_Flow_Ctrl;
 
     // MAC_RxQ_Ctrl4 @ 0x0094 = 0x0:
     // The Receive Queue Control 4 register controls the routing of unicast and
     // multicast packets that fail the Destination or Source address filter to the Rx
     // queues.
-    ULONG MacRxCtrl4;
+    ULONG Mac_RxQ_Ctrl4;
 
     ULONG Padding0098[2];
 
     // MAC_RxQ_Ctrl0 @ 0x00A0 = 0x0:
     // The Receive Queue Control 0 register controls the queue management in the MAC
     // Receiver.
-    ULONG MacRxCtrl0;
+    ULONG Mac_RxQ_Ctrl0;
 
     // MAC_RxQ_Ctrl1 @ 0x00A4 = 0x0:
     // The Receive Queue Control 1 register controls the routing of multicast,
     // broadcast, AV, DCB, and untagged packets to the Rx queues.
-    ULONG MacRxCtrl1;
+    ULONG Mac_RxQ_Ctrl1;
 
     // MAC_RxQ_Ctrl2 @ 0x00A8 = 0x0:
     // This register controls the routing of tagged packets based on the USP (user
     // Priority) field of the received packets to the RxQueues 0 to 3.
-    ULONG MacRxCtrl2;
+    ULONG Mac_RxQ_Ctrl2;
 
     ULONG Padding00AC[1];
 
     // MAC_Interrupt_Status @ 0x00B0 = 0x0:
     // The Interrupt Status register contains the status of interrupts.
-    MacInterruptStatus_t MacInterruptStatus;
+    MacInterruptStatus_t Mac_Interrupt_Status;
 
     // MAC_Interrupt_Enable @ 0x00B4 = 0x0:
     // The Interrupt Enable register contains the masks for generating the interrupts.
-    MacInterruptEnable_t MacInterruptEnable;
+    MacInterruptEnable_t Mac_Interrupt_Enable;
 
     // MAC_Rx_Tx_Status @ 0x00B8 = 0x0:
     // The Receive Transmit Status register contains the Receive and Transmit Error
     // status.
-    ULONG MacRxTxStatus;
+    ULONG Mac_Rx_Tx_Status;
 
     ULONG Padding00BC[1];
 
     // MAC_PMT_Control_Status @ 0x00C0 = 0x0:
     // The PMT Control and Status Register.
-    ULONG MacPmtControlStatus;
+    ULONG Mac_Pmt_Control_Status;
 
     // MAC_RWK_Packet_Filter @ 0x00C4 = 0x0:
     // The Remote Wakeup Filter registers are implemented as 8, 16, or 32 indirect
     // access registers (wkuppktfilter_reg#i) based on whether 4, 8, or 16 Remote
     // Wakeup Filters are selected in the configuration and accessed by application
     // through MacRWK_Packet_Filter register.
-    ULONG MacRwkPacketFilter;
+    ULONG Mac_Rwk_Packet_Filter;
 
     // RWK_Filter01_CRC @ 0x00C4 = 0x0:
     // RWK Filter 0/1 CRC-16.
@@ -1050,200 +1057,200 @@ struct MacRegisters
     // MAC_LPI_Control_Status @ 0x00D0 = 0x0:
     // The LPI Control and Status Register controls the LPI functions and provides the
     // LPI interrupt status. The status bits are cleared when this register is read.
-    MacLpiControlStatus_t MacLpiControlStatus;
+    MacLpiControlStatus_t Mac_Lpi_Control_Status;
 
     // MAC_LPI_Timers_Control @ 0x00D4 = 0x3E80000:
     // The LPI Timers Control register controls the timeout values in the LPI states.
-    ULONG MacLpiTimersControl;
+    ULONG Mac_Lpi_Timers_Control;
 
     // MAC_LPI_Entry_Timer @ 0x00D8 = 0x0:
     // This register controls the Tx LPI entry timer.
-    ULONG MacLpiEntryTimer;
+    ULONG Mac_Lpi_Entry_Timer;
 
     // MAC_1US_Tic_Counter @ 0x00DC = 0x3F:
     // This register controls the generation of the Reference time (1 microsecond
     // tic).
-    ULONG Mac1usTicCounter;
+    ULONG Mac_1us_Tic_Counter;
 
     ULONG Padding00E0[6];
 
     // MAC_PHYIF_Control_Status @ 0x00F8 = 0x0:
     // PHY Interface Control and Status Register.
-    MacPhyIfControlStatus_t MacPhyIfControlStatus;
+    MacPhyIfControlStatus_t Mac_PhyIf_Control_Status;
 
     ULONG Padding00FC[5];
 
     // MAC_Version @ 0x0110 = 0x3051:
     // The version register identifies the version of the GMAC.
-    MacVersion_t MacVersion;
+    MacVersion_t Mac_Version;
 
     // MAC_Debug @ 0x0114 = 0x0:
     // The Debug register provides the debug status of various MAC blocks.
-    ULONG MacDebug;
+    ULONG Mac_Debug;
 
     ULONG Padding0118[1];
 
     // MAC_HW_Feature0 @ 0x011C = 0x181173F3:
     // This register indicates the presence of first set of the optional features or
     // functions.
-    MacHwFeature0_t MacHwFeature0;
+    MacHwFeature0_t Mac_Hw_Feature0;
 
     // MAC_HW_Feature1 @ 0x0120 = 0x111E01E8:
     // This register indicates the presence of second set of the optional features or
     // functions.
-    MacHwFeature1_t MacHwFeature1;
+    MacHwFeature1_t Mac_Hw_Feature1;
 
     // MAC_HW_Feature2 @ 0x0124 = 0x11041041:
     // This register indicates the presence of third set of the optional features or
     // functions.
-    MacHwFeature2_t MacHwFeature2;
+    MacHwFeature2_t Mac_Hw_Feature2;
 
     // MAC_HW_Feature3 @ 0x0128 = 0xC370031:
     // This register indicates the presence of fourth set the optional features or
     // functions.
-    MacHwFeature3_t MacHwFeature3;
+    MacHwFeature3_t Mac_Hw_Feature3;
 
     ULONG Padding012C[53];
 
     // MAC_MDIO_Address @ 0x0200 = 0x0:
     // The MDIO Address register controls the management cycles to external PHY
     // through a management interface.
-    ULONG MacMdioAddress;
+    ULONG Mac_Mdio_Address;
 
     // MAC_MDIO_Data @ 0x0204 = 0x0:
     // The MDIO Data register stores the Write data to be written to the PHY register
     // located at the address specified in MacMDIO_Address.
-    ULONG MacMdioData;
+    ULONG Mac_Mdio_Data;
 
     ULONG Padding0208[2];
 
     // MAC_ARP_Address @ 0x0210 = 0x0:
     // The ARP Address register contains the IPv4 Destination Address of the MAC.
-    ULONG MacArpAddress;
+    ULONG Mac_Arp_Address;
 
     ULONG Padding0214[7];
 
     // MAC_CSR_SW_Ctrl @ 0x0230 = 0x0:
     // This register contains SW programmable controls for changing the CSR access
     // response and status bits clearing.
-    ULONG MacCsrSwCtrl;
+    ULONG Mac_Csr_Sw_Ctrl;
 
     // MAC_FPE_CTRL_STS @ 0x0234 = 0x0:
     // This register controls the operation of Frame Preemption.
-    ULONG MacFpeCtrlSts;
+    ULONG Mac_Fpe_Ctrl_Sts;
 
     // MAC_Ext_Cfg1 @ 0x0238 = 0x0:
     // This register contains Split mode control field and offset field for Split
     // Header feature.
-    ULONG MacExtCfg1;
+    ULONG Mac_Ext_Cfg1;
 
     ULONG Padding023C[1];
 
     // MAC_Presn_Time_ns @ 0x0240 = 0x0:
     // This register contains the 32- bit binary rollover equivalent time of the PTP
     // System Time in ns.
-    ULONG MacPresnTimeNS;
+    ULONG Mac_Presn_Time_NS;
 
     // MAC_Presn_Time_Updt @ 0x0244 = 0x0:
     // This field holds the 32-bit value of MAC 1722 Presentation Time in ns, that
     // should be added to the Current Presentation Time Counter value. Init happens
     // when TSINIT is set, and update happens when the TSUPDT bit is set (TSINIT and
     // TSINIT defined in MacTimestamp_Control register.
-    ULONG MacPresnTimeUpdt;
+    ULONG Mac_Presn_Time_Updt;
 
     ULONG Padding0248[46];
 
     // MAC_AddressX_High, MacAddressX_Low @ 0x0300, 0x0308, 0x0310, 0x0318.
-    MacAddressRegisters MacAddress[4];
+    MacAddressRegisters Mac_Address[4];
 
     ULONG Padding0320[248];
 
     // MMC_Control @ 0x0700 = 0x0:
     // This register establishes the operating mode of MMC.
-    ULONG MmcControl;
+    ULONG Mmc_Control;
 
     // MMC_Rx_Interrupt @ 0x0704 = 0x0:
     // Maintains the interrupts generated from all Receive statistics counters.
-    ULONG MmcRxInterrupt;
+    ULONG Mmc_Rx_Interrupt;
 
     // MMC_Tx_Interrupt @ 0x0708 = 0x0:
     // Maintains the interrupts generated from all Transmit statistics counters.
-    ULONG MmcTxInterrupt;
+    ULONG Mmc_Tx_Interrupt;
 
     // MMC_Rx_Interrupt_Mask @ 0x070C = 0x0:
     // This register maintains the masks for interrupts generated from all Receive
     // statistics counters.
-    ULONG MmcRxInterruptMask;
+    ULONG Mmc_Rx_InterruptMask;
 
     // MMC_Tx_Interrupt_Mask @ 0x0710 = 0x0:
     // This register maintains the masks for interrupts generated from all Transmit
     // statistics counters.
-    ULONG MmcTxInterruptMask;
+    ULONG Mmc_Tx_InterruptMask;
 
     // Tx_Octet_Count_Good_Bad @ 0x0714 = 0x0:
     // This register provides the number of bytes transmitted by the GMAC, exclusive
     // of preamble and retried bytes, in good and bad packets.
-    ULONG TxOctetCountGoodBad;
+    ULONG Tx_Octet_Count_Good_Bad;
 
     // Tx_Packet_Count_Good_Bad @ 0x0718 = 0x0:
     // This register provides the number of good and bad packets, exclusive of retried
     // packets.
-    ULONG TxPacketCountGoodBad;
+    ULONG Tx_Packet_Count_Good_Bad;
 
     ULONG Padding071C[11];
 
     // Tx_Underflow_Error_Packets @ 0x0748 = 0x0:
     // This register provides the number of packets aborted because of packets
     // underflow error.
-    ULONG TxUnderflowErrorPackets;
+    ULONG Tx_Underflow_Error_Packets;
 
     ULONG Padding074C[5];
 
     // Tx_Carrier_Error_Packets @ 0x0760 = 0x0:
     // This register provides the number of packets aborted because of carrier sense
     // error (no carrier or loss of carrier).
-    ULONG TxCarrierErrorPackets;
+    ULONG Tx_Carrier_Error_Packets;
 
     // Tx_Octet_Count_Good @ 0x0764 = 0x0:
     // This register provides the number of bytes exclusive of preamble, only in good
     // packets.
-    ULONG TxOctetCountGood;
+    ULONG Tx_Octet_Count_Good;
 
     // Tx_Packet_Count_Good @ 0x0768 = 0x0:
     // This register provides the number of good packets transmitted by GMAC.
-    ULONG TxPacketCountGood;
+    ULONG Tx_Packet_Count_Good;
 
     ULONG Padding076C[1];
 
     // Tx_Pause_Packets @ 0x0770 = 0x0:
     // This register provides the number of good Pause packets transmitted by GMAC.
-    ULONG TxPausePackets;
+    ULONG Tx_Pause_Packets;
 
     ULONG Padding0774[3];
 
     // Rx_Packets_Count_Good_Bad @ 0x0780 = 0x0:
     // This register provides the number of good and bad packets received by GMAC.
-    ULONG RxPacketCountGoodBad;
+    ULONG Rx_Packets_Count_Good_Bad;
 
     // Rx_Octet_Count_Good_Bad @ 0x0784 = 0x0:
     // This register provides the number of bytes received by GMAC, exclusive of
     // preamble, in good and bad packets.
-    ULONG RxOctetCountGoodBad;
+    ULONG Rx_Octet_Count_Good_Bad;
 
     // Rx_Octet_Count_Good @ 0x0788 = 0x0:
     // This register provides the number of bytes received by GMAC, exclusive of
     // preamble, only in good packets.
-    ULONG RxOctetCountGood;
+    ULONG Rx_Octet_Count_Good;
 
     ULONG Padding078C[1];
 
     // Rx_Multicast_Packets_Good @ 0x0790 = 0x0:
     // This register provides the number of good multicast packets received by GMAC.
-    ULONG RxMulticastPacketsGood;
+    ULONG Rx_Multicast_Packets_Good;
 
     // Rx_CRC_Error_Packets @ 0x0794 = 0x0:
     // This register provides the number of packets received by GMAC with CRC error.
-    ULONG RxCrcErrorPackets;
+    ULONG Rx_Crc_Error_Packets;
 
     ULONG Padding0798[4];
 
@@ -1252,7 +1259,7 @@ struct MacRegisters
     // with length greater than the maxsize (1,518 bytes or 1,522 bytes for VLAN
     // tagged packets; 2000 bytes if enabled in the S2KP bit of the MAC_Configuration
     // register).
-    ULONG RxOversizePacketsGood;
+    ULONG Rx_Oversize_Packets_Good;
 
     ULONG Padding07AC[7];
 
@@ -1260,19 +1267,19 @@ struct MacRegisters
     // This register provides the number of packets received by GMAC with length error
     // (Length Type field not equal to packet size), for all packets with valid length
     // field.
-    ULONG RxLengthErrorPackets;
+    ULONG Rx_Length_Error_Packets;
 
     ULONG Padding07CC[1];
 
     // Rx_Pause_Packets @ 0x07D0 = 0x0:
     // This register provides the number of good and valid Pause packets received by
     // GMAC.
-    ULONG RxPausePackets;
+    ULONG Rx_Pause_Packets;
 
     // Rx_FIFO_Overflow_Packets @ 0x07D4 = 0x0:
     // This register provides the number of missed received packets because of FIFO
     // overflow.
-    ULONG RxFifoOverflowPackets;
+    ULONG Rx_Fifo_Overflow_Packets;
 
     ULONG Padding07D8[1];
 
@@ -1283,145 +1290,145 @@ struct MacRegisters
     // bytes (when JE bit is set and WD bit is reset in MAC_Configuration register),
     // 16,384 bytes (when WD bit is set in MAC_Configuration register) or the value
     // programmed in the MAC_Watchdog_Timeout register).
-    ULONG RxWatchdogErrorPackets;
+    ULONG Rx_Watchdog_Error_Packets;
 
     ULONG Padding07E0[8];
 
     // MMC_IPC_Rx_Interrupt_Mask @ 0x0800 = 0x0:
     // This register maintains the mask for the interrupt generated from the receive
     // IPC statistic counters.
-    ULONG MmcIpcRxInterruptMask;
+    ULONG Mmc_Ipc_Rx_Interrupt_Mask;
 
     ULONG Padding0804[1];
 
     // MMC_IPC_Rx_Interrupt @ 0x0808 = 0x0:
     // This register maintains the interrupt that the receive IPC statistic counters
     // generate.
-    ULONG MmcIpcRxInterrupt;
+    ULONG Mmc_Ipc_Rx_Interrupt;
 
     ULONG Padding080C[1];
 
     // RxIPv4_Good_Packets @ 0x0810 = 0x0:
     // This register provides the number of good IPv4 datagrams received by GMAC with
     // the TCP, UDP, or ICMP payload.
-    ULONG RxIPv4GoodPackets;
+    ULONG RxIPv4_Good_Packets;
 
     // RxIPv4_Header_Error_Packets @ 0x0814 = 0x0:
     // This register provides the number of IPv4 datagrams received by GMAC with
     // header (checksum, length, or version mismatch) errors.
-    ULONG RxIPv4HeaderErrorPackets;
+    ULONG RxIPv4_Header_Error_Packets;
 
     ULONG Padding0818[3];
 
     // RxIPv6_Good_Packets @ 0x0824 = 0x0:
     // This register provides the number of good IPv6 datagrams received by GMAC.
-    ULONG RxIPv6GoodPackets;
+    ULONG RxIPv6_Good_Packets;
 
     // RxIPv6_Header_Error_Packets @ 0x0828 = 0x0:
     // This register provides the number of IPv6 datagrams received by GMAC with
     // header (length or version mismatch) errors.
-    ULONG RxIPv6HeaderErrorPackets;
+    ULONG RxIPv6_Header_Error_Packets;
 
     ULONG Padding082C[2];
 
     // RxUDP_Error_Packets @ 0x0834 = 0x0:
     // This register provides the number of good IP datagrams received by GMAC whose
     // UDP payload has a checksum error.
-    ULONG RxUdpErrorPackets;
+    ULONG RxUdp_Error_Packets;
 
     ULONG Padding0838[1];
 
     // RxTCP_Error_Packets @ 0x083C = 0x0:
     // This register provides the number of good IP datagrams received by GMAC whose
     // TCP payload has a checksum error.
-    ULONG RxTcpErrorPackets;
+    ULONG RxTcp_Error_Packets;
 
     ULONG Padding0840[1];
 
     // RxICMP_Error_Packets @ 0x0844 = 0x0:
     // This register provides the number of good IP datagrams received by GMAC whose
     // ICMP payload has a checksum error.
-    ULONG RxIcmpErrorPackets;
+    ULONG RxIcmp_Error_Packets;
 
     ULONG Padding0848[3];
 
     // RxIPv4_Header_Error_Octets @ 0x0854 = 0x0:
     // This register provides the number of bytes received by GMAC in IPv4 datagrams
     // with header errors (checksum, length, version mismatch).
-    ULONG RxIPv4HeaderErrorOctets;
+    ULONG RxIPv4_Header_Error_Octets;
 
     ULONG Padding0858[4];
 
     // RxIPv6_Header_Error_Octets @ 0x0868 = 0x0:
     // This register provides the number of bytes received by GMAC in IPv6 datagrams
     // with header errors (length, version mismatch).
-    ULONG RxIPv6HeaderErrorOctets;
+    ULONG RxIPv6_Header_Error_Octets;
 
     ULONG Padding086C[2];
 
     // RxUDP_Error_Octets @ 0x0874 = 0x0:
     // This register provides the number of bytes received by GMAC in a UDP segment
     // that had checksum errors.
-    ULONG RxUdpErrorOctets;
+    ULONG RxUdp_Error_Octets;
 
     ULONG Padding0878[1];
 
     // RxTCP_Error_Octets @ 0x087C = 0x0:
     // This register provides the number of bytes received by GMAC in a TCP segment
     // that had checksum errors.
-    ULONG RxTcpErrorOctets;
+    ULONG RxTcp_Error_Octets;
 
     ULONG Padding0880[1];
 
     // RxICMP_Error_Octets @ 0x0884 = 0x0:
     // This register provides the number of bytes received by GMAC in a good ICMP
     // segment.
-    ULONG RxIcmpErrorOctets;
+    ULONG RxIcmp_Error_Octets;
 
     ULONG Padding0888[6];
 
     // MMC_FPE_Tx_Interrupt @ 0x08A0 = 0x0:
     // This register maintains the interrupts generated from all FPE related Transmit
     // statistics counters.
-    ULONG MmcFpeTxInterrupt;
+    ULONG Mmc_Fpe_Tx_Interrupt;
 
     // MMC_FPE_Tx_Interrupt_Mask @ 0x08A4 = 0x0:
     // This register maintains the masks for interrupts generated from all FPE related
     // Transmit statistics counters.
-    ULONG MmcFpeTxInterruptMask;
+    ULONG Mmc_Fpe_Tx_Interrupt_Mask;
 
     // MmcTxFpeFragment_Cntr @ 0x08A8 = 0x0:
     // This register provides the number of additional mPackets transmitted due to
     // preemption.
-    ULONG MmcTxFpeFragmentCntr;
+    ULONG MmcTxFpeFragment_Cntr;
 
     // MMC_Tx_Hold_Req_Cntr @ 0x08AC = 0x0:
     // This register provides the count of number of times a hold request is given to
     // MAC.
-    ULONG MmcTxHoldReqCntr;
+    ULONG MMC_Tx_Hold_Req_Cntr;
 
     ULONG Padding08B0[4];
 
     // MMC_FPE_Rx_Interrupt @ 0x08C0 = 0x0:
     // This register maintains the interrupts generated from all FPE related Receive
     // statistics counters.
-    ULONG MmcFpeRxInterrupt;
+    ULONG Mmc_Fpe_Rx_Interrupt;
 
     // MMC_FPE_Rx_Interrupt_Mask @ 0x08C4 = 0x0:
     // This register maintains the masks for interrupts generated from all FPE related
     // Receive statistics counters.
-    ULONG MmcFpeRxInterruptMask;
+    ULONG Mmc_Fpe_Rx_Interrupt_Mask;
 
     // MMC_Rx_Packet_Asm_Err_Cntr @ 0x08C8 = 0x0:
     // This register provides the number of MAC frames with reassembly errors on the
     // Receiver, due to mismatch in the Fragment Count value.
-    ULONG MmcRxPacketAsmErrCntr;
+    ULONG Mmc_Rx_Packet_Asm_Err_Cntr;
 
     // MMC_Rx_Packet_SMD_Err_Cntr @ 0x08CC = 0x0:
     // This register provides the number of received MAC frames rejected due to
     // unknown SMD value and MAC frame fragments rejected due to arriving with an
     // SMD-C when there was no.
-    ULONG MmcRxPacketSmdErrCntr;
+    ULONG Mmc_Rx_Packet_SMD_Err_Cntr;
 
     // MMC_Rx_Packet_Assembly_OK_Cntr @ 0x08D0 = 0x0:
     // This register provides the number of MAC frames that were successfully
@@ -1431,75 +1438,75 @@ struct MacRegisters
     // MMC_Rx_FPE_Fragment_Cntr @ 0x08D4 = 0x0:
     // This register provides the number of additional mPackets transmitted due to
     // preemption.
-    ULONG MmcRxFpeFragmentCntr;
+    ULONG Mmc_Rx_Fpe_Fragment_Cntr;
 
     ULONG Padding08D8[10];
 
     // MAC_L3_L4 filters @ 0x0900, 0x0930.
-    MacL3L4Registers MacL3L4[2];
+    MacL3L4Registers Mac_L3_L4[2];
 
     ULONG Padding0950[104];
 
     // MAC_Timestamp_Control @ 0x0B00 = 0x0:
     // This register controls the operation of the System Time generator and
     // processing of PTP packets for timestamping in the Receiver.
-    ULONG MacTimestampControl;
+    ULONG Mac_Timestamp_Control;
 
     // MAC_Sub_Second_Increment @ 0x0B04 = 0x0:
     // Specifies the value to be added to the internal system time register every
     // cycle of clk_ptp_ref_i clock.
-    ULONG MacSubSecondIncrement;
+    ULONG Mac_Sub_Second_Increment;
 
     // MAC_System_Time_Secs @ 0x0B08 = 0x0:
     // The System Time Nanoseconds register, along with System Time Seconds register,
     // indicates the current value of the system time maintained by the MAC.
-    ULONG MacSystemTimeSecs;
+    ULONG Mac_System_Time_Secs;
 
     // MAC_System_Time_NS @ 0x0B0C = 0x0:
     // The System Time Nanoseconds register, along with System Time Seconds register,
     // indicates the current value of the system time maintained by the MAC.
-    ULONG MacSystemTimeNS;
+    ULONG Mac_System_Time_NS;
 
     // MAC_Sys_Time_Secs_Update @ 0x0B10 = 0x0:
     // The System Time Seconds Update register, along with the System Time Nanoseconds
     // Update register, initializes or updates the system time maintained by the MAC.
-    ULONG MacSysTimeSecsUpdate;
+    ULONG Mac_Sys_Time_Secs_Update;
 
     // MAC_Sys_Time_NS_Update @ 0x0B14 = 0x0:
     // MAC System Time Nanoseconds Update register.
-    ULONG MacSysTimeNsUpdate;
+    ULONG Mac_Sys_Time_NS_Update;
 
     // MAC_Timestamp_Addend @ 0x0B18 = 0x0:
     // Timestamp Addend register.  This register value is used only when the system
     // time is configured for Fine Update mode (TSCFUPDT bit in the
     // MacTimestamp_Control register).
-    ULONG MacTimestampAddend;
+    ULONG Mac_Timestamp_Addend;
 
     ULONG Padding0B1C[1];
 
     // MAC_Timestamp_Status @ 0x0B20 = 0x0:
     // Timestamp Status register. All bits except Bits[27:25] gets cleared when the
     // application reads this register.
-    ULONG MacTimestampStatus;
+    ULONG Mac_Timestamp_Status;
 
     ULONG Padding0B24[3];
 
     // MAC_Tx_TS_Status_NS @ 0x0B30 = 0x0:
     // This register contains the nanosecond part of timestamp captured for Transmit
     // packets when Tx status is disabled.
-    ULONG MacTxTsStatusNS;
+    ULONG Mac_Tx_TS_Status_NS;
 
     // MAC_Tx_TS_Status_Secs @ 0x0B34 = 0x0:
     // The register contains the higher 32 bits of the timestamp (in seconds) captured
     // when a PTP packet is transmitted.
-    ULONG MacTxTsStatusSecs;
+    ULONG Mac_Tx_TS_Status_Secs;
 
     ULONG Padding0B38[2];
 
     // MAC_Auxiliary_Control @ 0x0B40 = 0x0:
     // The Auxiliary Timestamp Control register controls the Auxiliary Timestamp
     // snapshot.
-    ULONG MacAuxiliaryControl;
+    ULONG Mac_Auxiliary_Control;
 
     ULONG Padding0B44[1];
 
@@ -1507,38 +1514,38 @@ struct MacRegisters
     // The Auxiliary Timestamp Nanoseconds register, along with
     // MacAuxiliary_Timestamp_Seconds, gives the 64-bit timestamp stored as auxiliary
     // snapshot.
-    ULONG MacAuxiliaryTsNS;
+    ULONG Mac_Auxiliary_TS_NS;
 
     // MAC_Auxiliary_TS_Secs @ 0x0B4C = 0x0:
     // The Auxiliary Timestamp - Seconds register contains the lower 32 bits of the
     // Seconds field of the auxiliary timestamp register.
-    ULONG MacAuxiliaryTsSecs;
+    ULONG Mac_Auxiliary_TS_Secs;
 
     ULONG Padding0B50[2];
 
     // MAC_TS_Ingress_Corr_NS @ 0x0B58 = 0x0:
     // This register contains the correction value in nanoseconds to be used with the
     // captured timestamp value in the ingress path.
-    ULONG MacTsIngressCorrNS;
+    ULONG Mac_TS_Ingress_Corr_NS;
 
     // MAC_TS_Egress_Corr_NS @ 0x0B5C = 0x0:
     // This register contains the correction value in nanoseconds to be used with the
     // captured timestamp value in the egress path.
-    ULONG MacTsEgressCorrNS;
+    ULONG Mac_TS_Egress_Corr_NS;
 
     ULONG Padding0B60[2];
 
     // MAC_TS_Ingress_Latency @ 0x0B68 = 0x0:
     // This register holds the Ingress MAC latency.
-    ULONG MacTsIngressLatency;
+    ULONG Mac_TS_Ingress_Latency;
 
     // MAC_TS_Egress_Latency @ 0x0B6C = 0x0:
     // This register holds the Egress MAC latency.
-    ULONG MacTsEgressLatency;
+    ULONG Mac_TS_Egress_Latency;
 
     // MAC_PPS_Control @ 0x0B70 = 0x0:
     // PPS Control register.
-    ULONG MacPpsControl;
+    ULONG Mac_Pps_Control;
 
     ULONG Padding0B74[3];
 
@@ -1547,96 +1554,96 @@ struct MacRegisters
     // register, is used to schedule an interrupt event [Bit 1 of
     // MacTimestamp_Status] when the system time exceeds the value programmed in
     // these registers.
-    ULONG MacPps0TargetTimeSeconds;
+    ULONG Mac_Pps0_Target_Time_Seconds;
 
     // MAC_PPS0_Target_Time_Ns @ 0x0B84 = 0x0:
     // PPS0 Target Time Nanoseconds register.
-    ULONG MacPps0TargetTimeNs;
+    ULONG Mac_Pps0_Target_Time_NS;
 
     // MAC_PPS0_Interval @ 0x0B88 = 0x0:
     // The PPS0 Interval register contains the number of units of sub-second increment
     // value between the rising edges of PPS0 signal output (ptp_pps_o[0]).
-    ULONG MacPps0Interval;
+    ULONG Mac_Pps0_Interval;
 
     // MAC_PPS0_Width @ 0x0B8C = 0x0:
     // The PPS0 Width register contains the number of units of sub-second increment
     // value.
-    ULONG MacPps0Width;
+    ULONG Mac_Pps0_Width;
 
     ULONG Padding0B90[28];
 
     // MTL_Operation_Mode @ 0x0C00 = 0x0:
     // The Operation Mode register establishes the Transmit and Receive operating
     // modes and commands.
-    ULONG MtlOperationMode;
+    ULONG Mtl_Operation_Mode;
 
     ULONG Padding0C04[1];
 
     // MTL_DBG_CTL @ 0x0C08 = 0x0:
     // The FIFO Debug Access Control and Status register controls the operation mode
     // of FIFO debug access.
-    ULONG MtlDbgCtl;
+    ULONG Mtl_Dbg_Ctl;
 
     // MTL_DBG_STS @ 0x0C0C = 0x1900000:
     // The FIFO Debug Status register contains the status of FIFO debug access.
-    ULONG MtlDebugStatus;
+    ULONG Mtl_Dbg_Sts;
 
     // MTL_FIFO_Debug_Data @ 0x0C10 = 0x0:
     // The FIFO Debug Data register contains the data to be written to or read from
     // the FIFOs.
-    ULONG MtlFifoDebugData;
+    ULONG Mtl_Fifo_Debug_Data;
 
     ULONG Padding0C14[3];
 
     // MTL_Interrupt_Status @ 0x0C20 = 0x0:
     // The software driver (application) reads this register during interrupt service
     // routine or polling to determine the interrupt status of MTL queues and the MAC.
-    ULONG MtlInterruptStatus;
+    ULONG Mtl_Interrupt_Status;
 
     ULONG Padding0C24[3];
 
     // MTL_RxQ_DMA_Map0 @ 0x0C30 = 0x0:
     // The Receive Queue and DMA Channel Mapping 0 register is reserved in EQOS-CORE
     // and EQOS-MTL configurations.
-    ULONG MtlRxDmaMap0;
+    ULONG Mtl_RxQ_Dma_Map0;
 
     ULONG Padding0C34[3];
 
     // MTL_TBS_CTRL @ 0x0C40 = 0x0:
     // This register controls the operation of Time Based Scheduling.
-    ULONG MtlTbsCtrl;
+    ULONG Mtl_Tbs_Ctrl;
 
     ULONG Padding0C44[3];
 
     // MTL_EST_Control @ 0x0C50 = 0x0:
     // This register controls the operation of Enhancements to Scheduled Transmission
     // (IEEE802.1Qbv).
-    ULONG MtlEstControl;
+    ULONG Mtl_Est_Control;
 
     ULONG Padding0C54[1];
 
     // MTL_EST_Status @ 0x0C58 = 0x0:
     // This register provides Status related to Enhancements to Scheduled
     // Transmission.
-    ULONG MtlEstStatus;
+    ULONG Mtl_Est_Status;
 
     ULONG Padding0C5C[1];
 
     // MTL_EST_Sch_Error @ 0x0C60 = 0x0:
     // This register provides the One Hot encoded Queue Numbers that are having the
     // Scheduling related error (timeout).
-    ULONG MtlEstSchError;
+    ULONG Mtl_Est_Sch_Error;
 
     // MTL_EST_Frm_Size_Error @ 0x0C64 = 0x0:
     // This register provides the One Hot encoded Queue Numbers that are having the
     // Frame.
-    ULONG MtlEstFrmSizeError;
+    ULONG Mtl_Est_Frm_Size_Error;
 
     // MTL_EST_Frm_Size_Capture @ 0x0C68 = 0x0:
     // This register captures the Frame Size and Queue Number of the first occurrence
     // of the Frame Size related error. Up on clearing it captures the data of
     // immediate next occurrence of a similar error.
-    ULONG MtlEstFrmSizeCapture;
+    ULONG Mtl_Est_Frm_Size_Capture;
 
     ULONG Padding0C6C[1];
 
@@ -1644,74 +1651,74 @@ struct MacRegisters
     // This register implements the Interrupt Enable bits for the various events that
     // generate an interrupt. Bit positions have a 1 to 1 correlation with the status
     // bit positions in MtlETS_Status.
-    ULONG MtlEstIntrEnable;
+    ULONG Mtl_Est_Intr_Enable;
 
     ULONG Padding0C74[3];
 
     // MTL_EST_GCL_Control @ 0x0C80 = 0x0:
     // This register provides the control information for reading/writing to the Gate
     // Control lists.
-    ULONG MtlEstGclControl;
+    ULONG Mtl_Est_Gcl_Control;
 
     // MTL_EST_GCL_Data @ 0x0C84 = 0x0:
     // This register holds the read data or write data in case of reads and writes
     // respectively.
-    ULONG MtlEstGclData;
+    ULONG Mtl_Est_Gcl_Data;
 
     ULONG Padding0C88[2];
 
     // MTL_FPE_CTRL_STS @ 0x0C90 = 0x0:
     // This register controls the operation of, and provides status for Frame
     // Preemption (IEEE802.1Qbu/802.3br).
-    ULONG MtlFpeCtrlSts;
+    ULONG Mtl_Fpe_Ctrl_Sts;
 
     // MTL_FPE_Advance @ 0x0C94 = 0x0:
     // This register holds the Hold and Release Advance time.
-    ULONG MtlFpeAdvance;
+    ULONG Mtl_Fpe_Advance;
 
     ULONG Padding0C98[26];
 
     // MTL_Qx @ 0x0D00, 0x0D40.
-    MtlQueueRegisters MtlQ[2];
+    MtlQueueRegisters Mtl_Q[2];
 
     ULONG Padding0D80[160];
 
     // DMA_Mode @ 0x1000 = 0x0:
     // The Bus Mode register establishes the bus operating modes for the DMA.
-    ULONG DmaMode;
+    ULONG Dma_Mode;
 
     // DMA_SysBus_Mode @ 0x1004 = 0x10000:
     // The System Bus mode register controls the behavior of the AHB or AXI master.
-    DmaSysBusMode_t DmaSysBusMode;
+    DmaSysBusMode_t Dma_SysBus_Mode;
 
     // DMA_Interrupt_Status @ 0x1008 = 0x0:
     // The application reads this Interrupt Status register during interrupt service
     // routine or polling to determine the interrupt status of DMA channels, MTL
     // queues, and the MAC.
-    ULONG DmaInterruptStatus;
+    ULONG Dma_Interrupt_Status;
 
     // DMA_Debug_Status0 @ 0x100C = 0x0:
     // The Debug Status 0 register gives the Receive and Transmit process status for
     // DMA Channel 0-Channel 2 for debugging purpose.
-    ULONG DmaDebugStatus0;
+    ULONG Dma_Debug_Status0;
 
     ULONG Padding1010[12];
 
     // AXI_LPI_Entry_Interval @ 0x1040 = 0x0:
     // This register is used to control the AXI LPI entry interval.
-    ULONG AxiLpiEntryInterval;
+    ULONG Axi_Lpi_Entry_Interval;
 
     ULONG Padding1044[3];
 
     // DMA_TBS_CTRL @ 0x1050 = 0x0:
     // This register is used to control the TBS attributes.
-    ULONG DmaTbsCtrl;
+    ULONG Dma_Tbs_Ctrl;
 
     ULONG Padding1054[43];
     
     // DMA_CH0 @ 0x1100.
     // DMA_CH1 @ 0x1180.
-    ChannelRegisters DmaCh[2];
+    ChannelRegisters Dma_Ch[2];
 };
 static_assert(sizeof(MacRegisters) == 0x1200);
 
@@ -1719,7 +1726,16 @@ static_assert(sizeof(MacRegisters) == 0x1200);
 
 #pragma region DmaDescriptor
 
-#define DESCRIPTOR_ALIGN 64
+constexpr unsigned DESCRIPTOR_ALIGN = 64u;
+
+#if DBG
+#define TX_DESCRIPTOR_SIZE 24
+#define RX_DESCRIPTOR_SIZE 20
+#else
+#define TX_DESCRIPTOR_SIZE 16
+#define RX_DESCRIPTOR_SIZE 16
+#endif
+
 
 enum TxChecksumInsertion : UINT16
 {
@@ -1759,12 +1775,12 @@ struct TxDescriptorRead
     UINT16 ContextType : 1; // CTXT = 0
     UINT16 Own : 1; // OWN
 
-    // DEBUG
-
+#if DBG
     UINT32 FragmentIndex;
     UINT32 PacketIndex;
+#endif
 };
-static_assert(sizeof(TxDescriptorRead) == 24);
+static_assert(sizeof(TxDescriptorRead) == TX_DESCRIPTOR_SIZE);
 
 struct TxDescriptorReadTso
 {
@@ -1794,12 +1810,12 @@ struct TxDescriptorReadTso
     UINT32 ContextType : 1; // CTXT = 0
     UINT32 Own : 1; // OWN
 
-    // DEBUG
-
+#if DBG
     UINT32 FragmentIndex;
     UINT32 PacketIndex;
+#endif
 };
-static_assert(sizeof(TxDescriptorReadTso) == 24);
+static_assert(sizeof(TxDescriptorReadTso) == TX_DESCRIPTOR_SIZE);
 
 struct TxDescriptorWrite
 {
@@ -1840,12 +1856,12 @@ struct TxDescriptorWrite
     UINT8 ContextType : 1; // CTXT = 0
     UINT8 Own : 1; // OWN
 
-    // DEBUG
-
+#if DBG
     UINT32 FragmentIndex;
     UINT32 PacketIndex;
+#endif
 };
-static_assert(sizeof(TxDescriptorWrite) == 24);
+static_assert(sizeof(TxDescriptorWrite) == TX_DESCRIPTOR_SIZE);
 
 struct TxDescriptorContext
 {
@@ -1877,12 +1893,12 @@ struct TxDescriptorContext
     UINT8 Reserved28 : 2;
     UINT8 ContextType : 1; // CTXT = 1
 
-    // DEBUG
-
+#if DBG
     UINT32 FragmentIndex;
     UINT32 PacketIndex;
+#endif
 };
-static_assert(sizeof(TxDescriptorContext) == 24);
+static_assert(sizeof(TxDescriptorContext) == TX_DESCRIPTOR_SIZE);
 
 union TxDescriptor
 {
@@ -1916,11 +1932,11 @@ struct RxDescriptorRead
     UINT8 InterruptOnCompletion : 1; // IOC
     UINT8 Own : 1; // OWN
 
-    // DEBUG
-
+#if DBG
     UINT32 FragmentIndex;
+#endif
 };
-static_assert(sizeof(RxDescriptorRead) == 20);
+static_assert(sizeof(RxDescriptorRead) == RX_DESCRIPTOR_SIZE);
 
 struct RxDescriptorWrite
 {
@@ -1983,11 +1999,11 @@ struct RxDescriptorWrite
     UINT8 ContextType : 1; // CTXT = 0
     UINT8 Own : 1; // OWN
 
-    // DEBUG
-
+#if DBG
     UINT32 FragmentIndex;
+#endif
 };
-static_assert(sizeof(RxDescriptorWrite) == 20);
+static_assert(sizeof(RxDescriptorWrite) == RX_DESCRIPTOR_SIZE);
 
 struct RxDescriptorContext
 {
@@ -2004,11 +2020,11 @@ struct RxDescriptorContext
     UINT8 ContextType : 1; // CTXT = 0
     UINT8 Own : 1; // OWN
 
-    // DEBUG
-
+#if DBG
     UINT32 FragmentIndex;
+#endif
 };
-static_assert(sizeof(RxDescriptorContext) == 20);
+static_assert(sizeof(RxDescriptorContext) == RX_DESCRIPTOR_SIZE);
 
 union RxDescriptor
 {

--- a/drivers/net/dwc_eqos/rxqueue.h
+++ b/drivers/net/dwc_eqos/rxqueue.h
@@ -1,11 +1,14 @@
+/*
+Receive queue behavior. Similar to the transmit queue.
+*/
 #pragma once
 
 struct ChannelRegisters;
 auto constexpr RxBufferSize = 2048u;
 
+// Called by device.cpp AdapterCreateRxQueue.
 _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
-//__declspec(code_seg("PAGE")) // Nonpaged - on resume path.
 NTSTATUS
 RxQueueCreate(
     _In_ NETADAPTER adapter,

--- a/drivers/net/dwc_eqos/trace.h
+++ b/drivers/net/dwc_eqos/trace.h
@@ -1,6 +1,21 @@
+/*
+Trace macros.
+
+Collect traces using something like:
+
+    tracelog -start SessionName -f FileName.etl -guid *dwc_eqos -level 4
+    tracelog -stop SessionName
+    tracefmt FileName.etl
+
+Send traces to KD by running "!wmitrace.dynamicprint 1" in WinDbg and starting a trace
+session with -kd enabled, either via trace tool or via autologger:
+
+    tracelog -start SessionName -guid *dwc_eqos -level 4 -kd
+*/
 #pragma once
 
-// *dwc_eqos = {5d8331d3-70b3-5620-5664-db28f48a4b79}
+// Provider name "dwc_eqos".
+// Provider guid {5d8331d3-70b3-5620-5664-db28f48a4b79} = Hash("dwc_eqos").
 TRACELOGGING_DECLARE_PROVIDER(TraceProvider);
 
 enum : UINT8
@@ -12,6 +27,7 @@ enum : UINT8
     LEVEL_VERBOSE  = WINEVENT_LEVEL_VERBOSE,
 };
 
+// Event categories:
 #define KW_GENERAL    TraceLoggingKeyword(0x1) // All events should have at least one keyword.
 #define KW_ENTRY_EXIT TraceLoggingKeyword(0x2)
 
@@ -19,11 +35,11 @@ enum : UINT8
 #define TraceWrite(eventName, level, ...) \
     TraceLoggingWrite(TraceProvider, eventName, TraceLoggingLevel(level), KW_GENERAL, __VA_ARGS__)
 
-// TraceLoggingWrite("funcName", KW_ENTRY_EXIT, ...).
+// TraceLoggingWrite(">=< funcName", KW_ENTRY_EXIT, ...).
 #define TraceEntryExit(funcName, level, ...) \
-    TraceWrite(#funcName, level, KW_ENTRY_EXIT, __VA_ARGS__) \
+    TraceWrite(">=< " #funcName, level, KW_ENTRY_EXIT, __VA_ARGS__) \
 
-// TraceLoggingWrite("funcName", KW_ENTRY_EXIT, status, ...)
+// TraceLoggingWrite(">=< funcName", KW_ENTRY_EXIT, status, ...)
 #define TraceEntryExitWithStatus(funcName, successLevel, status, ...) \
     if (NTSTATUS const _status = (status); NT_SUCCESS(_status)) { \
         TraceEntryExit(funcName, successLevel, TraceLoggingNTStatus(_status, "status"), __VA_ARGS__); \
@@ -31,15 +47,15 @@ enum : UINT8
         TraceEntryExit(funcName, LEVEL_ERROR, TraceLoggingNTStatus(_status, "status"), __VA_ARGS__); \
     } \
 
-// TraceLoggingWrite("funcName-Entry", KW_ENTRY_EXIT, ...).
+// TraceLoggingWrite(">>> funcName", KW_ENTRY_EXIT, ...).
 #define TraceEntry(funcName, level, ...) \
-    TraceWrite(#funcName "-Entry", level, KW_ENTRY_EXIT, __VA_ARGS__) \
+    TraceWrite(">>> " #funcName, level, KW_ENTRY_EXIT, __VA_ARGS__) \
 
-// TraceLoggingWrite("funcName-Exit", KW_ENTRY_EXIT, ...).
+// TraceLoggingWrite("<<< funcName", KW_ENTRY_EXIT, ...).
 #define TraceExit(funcName, level, ...) \
-    TraceWrite(#funcName "-Exit", level, KW_ENTRY_EXIT, __VA_ARGS__) \
+    TraceWrite("<<< " #funcName, level, KW_ENTRY_EXIT, __VA_ARGS__) \
 
-// TraceLoggingWrite("funcName-Exit", KW_ENTRY_EXIT, status, ...)
+// TraceLoggingWrite("<<< funcName", KW_ENTRY_EXIT, status, ...)
 #define TraceExitWithStatus(funcName, successLevel, status, ...) \
     if (NTSTATUS const _status = (status); NT_SUCCESS(_status)) { \
         TraceExit(funcName, successLevel, TraceLoggingNTStatus(_status, "status"), __VA_ARGS__); \

--- a/drivers/net/dwc_eqos/txqueue.h
+++ b/drivers/net/dwc_eqos/txqueue.h
@@ -1,11 +1,14 @@
+/*
+Transmit queue behavior. Similar to the receive queue.
+*/
 #pragma once
 
 struct ChannelRegisters;
 struct MtlQueueRegisters;
 
+// Called by device.cpp AdapterCreateTxQueue.
 _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
-//__declspec(code_seg("PAGE")) // Nonpaged - on resume path.
 NTSTATUS
 TxQueueCreate(
     _In_ NETADAPTER adapter,


### PR DESCRIPTION
- Rename the registers to more-closely match the names in the TRD.
- Add or enhance comments.
- Include Fragment/Packet indexes only in Debug builds.