### PR TITLE
dwc_eqos - queue tuning

### DIFF
--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -5,7 +5,7 @@
 /*
 TODO list:
 - Support for 10/100 Mbps modes (requires ACPI support).
-- Use ACPI to get DMA configuration.
+- Use ACPI to get AXI configuration (and/or tune AXI config).
 - Jumbo frames.
 - Receive queue memory optimization?
 - Configuration in registry (e.g. flow control).

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -303,8 +303,8 @@ union MtlTxOperationMode_t
         MtlTxQueueEnable_t QueueEnable : 2; // TXQEN
         UINT32 ThresholdControl : 3; // TTC
         UINT32 Reserved7 : 9;
-        UINT32 QueueSize : 6; // TQS
-        UINT32 Reserved22 : 10;
+        UINT32 QueueSize : 12; // TQS
+        UINT32 Reserved28 : 4;
     };
 };
 
@@ -341,8 +341,7 @@ union MtlRxOperationMode_t
         UINT32 HardwareFlowControl : 1; // EHFC
         UINT32 FlowControlActivate : 6; // RFA
         UINT32 FlowControlDeactivate : 6; // RFD
-        UINT32 QueueSize : 7; // RQS
-        UINT32 Reserved27 : 5;
+        UINT32 QueueSize : 12; // RQS
     };
 };
 


### PR DESCRIPTION
- Try to tune the flow control on the Rx queue. Seemed to have a minor throughput improvement from sending pause packet at about half full.
- Make the flow control tuning more generic so it will work with buffer sizes other than the sizes in the RK3588.
- Try to tune the AXI parameters. Almost nothing I did seemed to have a consistent effect. I think there was a small improvement by enabling address-aligned beats, though it might just be my imagination.