### PR TITLE
dwc_eqos - checksum offload

### DIFF
--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -9,7 +9,6 @@ TODO list:
 - Jumbo frames.
 - Receive queue memory optimization?
 - Configuration in registry (e.g. flow control).
-- Checksum offload.
 - Tx segmentation offload.
 - Rx segmentation offload.
 - Wake-on-LAN.

--- a/drivers/net/dwc_eqos/dwc_eqos.inf
+++ b/drivers/net/dwc_eqos/dwc_eqos.inf
@@ -76,12 +76,53 @@ HKR, Ndi\Interfaces, UpperRange, 0, "ndis5"
 HKR, Ndi\Interfaces, LowerRange, 0, "ethernet"
 
 [DWCEQOS_AddReg_Ndi_params]
+
 HKR, Ndi\params\NetworkAddress, ParamDesc, 0, %NetworkAddress%
 HKR, Ndi\params\NetworkAddress, type,      0, "edit"
 HKR, Ndi\params\NetworkAddress, default,   0, ""
 HKR, Ndi\params\NetworkAddress, LimitText, 0, "12"
 HKR, Ndi\params\NetworkAddress, UpperCase, 0, "1"
 HKR, Ndi\params\NetworkAddress, Optional,  0, "1"
+
+HKR, Ndi\params\*IPChecksumOffloadIPv4,          ParamDesc,      0,  %IPChksumOffV4%
+HKR, Ndi\params\*IPChecksumOffloadIPv4,          default,        0,  "3"
+HKR, Ndi\params\*IPChecksumOffloadIPv4,          type,           0,  "enum"
+HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "0",            0,  %Disabled%
+HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "1",            0,  %TxEnabled%
+HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "2",            0,  %RxEnabled%
+HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "3",            0,  %RxTxEnabled%
+
+HKR, Ndi\params\*TCPChecksumOffloadIPv4,         ParamDesc,      0,  %TCPChksumOffV4%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4,         default,        0,  "3"
+HKR, Ndi\params\*TCPChecksumOffloadIPv4,         type,           0,  "enum"
+HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "0",            0,  %Disabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "1",            0,  %TxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "2",            0,  %RxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "3",            0,  %RxTxEnabled%
+
+HKR, Ndi\params\*UDPChecksumOffloadIPv4,         ParamDesc,      0,  %UDPChksumOffV4%
+HKR, Ndi\params\*UDPChecksumOffloadIPv4,         default,        0,  "3"
+HKR, Ndi\params\*UDPChecksumOffloadIPv4,         type,           0,  "enum"
+HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "0",            0,  %Disabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "1",            0,  %TxEnabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "2",            0,  %RxEnabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "3",            0,  %RxTxEnabled%
+
+HKR, Ndi\params\*TCPChecksumOffloadIPv6,         ParamDesc,      0,  %TCPChksumOffV6%
+HKR, Ndi\params\*TCPChecksumOffloadIPv6,         default,        0,  "3"
+HKR, Ndi\params\*TCPChecksumOffloadIPv6,         type,           0,  "enum"
+HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "0",            0,  %Disabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "1",            0,  %TxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "2",            0,  %RxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "3",            0,  %RxTxEnabled%
+
+HKR, Ndi\params\*UDPChecksumOffloadIPv6,         ParamDesc,      0,  %UDPChksumOffV6%
+HKR, Ndi\params\*UDPChecksumOffloadIPv6,         default,        0,  "3"
+HKR, Ndi\params\*UDPChecksumOffloadIPv6,         type,           0,  "enum"
+HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "0",            0,  %Disabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "1",            0,  %TxEnabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "2",            0,  %RxEnabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "3",            0,  %RxTxEnabled%
 
 [DWCEQOS_Device.NT.Services]
 AddService = %ServiceName%, 2, DWCEQOS_AddService, DWCEQOS_AddService_EventLog
@@ -111,11 +152,20 @@ KmdfService = %ServiceName%, DWCEQOS_KmdfService
 KmdfLibraryVersion = $KMDFVERSION$
 
 [Strings]
-ProviderName = "Open Source"
-NetworkAddress = "Network Address"
-RKCP = "Rockchip"
-DWCEQOS.DeviceDesc = "Synopsys DesignWare Ethernet Quality of Service (GMAC)"
+ProviderName        = "Open Source"
+NetworkAddress      = "Network Address"
+RKCP                = "Rockchip"
+DWCEQOS.DeviceDesc  = "Synopsys DesignWare Ethernet Quality of Service (GMAC)"
 DWCEQOS.ServiceDesc = "DesignWare Ethernet"
+IPChksumOffV4       = "IPv4 Checksum Offload"
+TCPChksumOffV4      = "TCP Checksum Offload (IPv4)"
+UDPChksumOffV4      = "UDP Checksum Offload (IPv4)"
+TCPChksumOffV6      = "TCP Checksum Offload (IPv6)"
+UDPChksumOffV6      = "UDP Checksum Offload (IPv6)"
+Disabled            = "Disabled"
+TxEnabled           = "Tx Enabled"
+RxEnabled           = "Rx Enabled"
+RxTxEnabled         = "Rx & Tx Enabled"
 
 ; Not localized
 ServiceName = "dwc_eqos"

--- a/drivers/net/dwc_eqos/precomp.h
+++ b/drivers/net/dwc_eqos/precomp.h
@@ -10,6 +10,7 @@
 #include <netadaptercx.h>
 #include <net/logicaladdress.h>
 #include <net/virtualaddress.h>
+#include <net/checksum.h>
 #include <initguid.h>
 #include <TraceLoggingProvider.h>
 #include <winmeta.h>

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -1735,7 +1735,6 @@ constexpr unsigned DESCRIPTOR_ALIGN = 64u;
 #define RX_DESCRIPTOR_SIZE 16
 #endif
 
-
 enum TxChecksumInsertion : UINT16
 {
     TxChecksumInsertionDisabled = 0,
@@ -1937,6 +1936,18 @@ struct RxDescriptorRead
 };
 static_assert(sizeof(RxDescriptorRead) == RX_DESCRIPTOR_SIZE);
 
+enum RxPayloadType : UINT8
+{
+    RxPayloadTypeUnknown = 0,
+    RxPayloadTypeUdp,
+    RxPayloadTypeTcp,
+    RxPayloadTypeIcmp,
+    RxPayloadTypeIgmp,
+    RxPayloadTypeAvUntaggedControl,
+    RxPayloadTypeAvTaggedData,
+    RxPayloadTypeAvTaggedControl,
+};
+
 struct RxDescriptorWrite
 {
     // RDES0
@@ -1946,7 +1957,7 @@ struct RxDescriptorWrite
 
     // RDES1
 
-    UINT8 PayloadType : 3; // PT
+    RxPayloadType PayloadType : 3; // PT
     UINT8 IPHeaderError : 1; // IPHE
     UINT8 IPv4HeaderPresent : 1; // IPV4
     UINT8 IPv6HeaderPresent : 1; // IPV6

--- a/drivers/net/dwc_eqos/txqueue.h
+++ b/drivers/net/dwc_eqos/txqueue.h
@@ -16,4 +16,5 @@ TxQueueCreate(
     _Inout_ NETTXQUEUE_INIT* queueInit,
     _In_ WDFDMAENABLER dma,
     _Inout_ ChannelRegisters* channelRegs,
-    _Inout_ MtlQueueRegisters* mtlRegs);
+    _Inout_ MtlQueueRegisters* mtlRegs,
+    bool checksumOffloadEnabled);


### PR DESCRIPTION
Implement checksum offload.

- Enable the checksum offload engine in hardware if present.
- Disable automatic drop of invalid-checksum packets for the case where the Rx offload gets turned off in software.
- Inform NetAdapterCx of the hardware capabilities.
- Add relevant properties to the driver's property sheet. (These are handled by NetAdapterCx.)
- Propagate offload information between descriptors and packets.

In testing, I didn't really see any difference in throughput or CPU usage with this enabled or disabled. Maybe I'm testing wrong.