### PR TITLE
dwc_eqos - Load ACPI configuration information

### DIFF
--- a/drivers/include/acpiutil.hpp
+++ b/drivers/include/acpiutil.hpp
@@ -22,6 +22,8 @@
 
 #ifndef __ACPIUTIL_HPP__
 #define __ACPIUTIL_HPP__
+#pragma once
+#include <acpiioct.h>
 
 #define NONPAGED_SEGMENT_BEGIN \
     __pragma(code_seg(push)) \
@@ -112,7 +114,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 AcpiQueryDsd(
     _In_ DEVICE_OBJECT* PdoPtr,
-    _Outptr_result_bytebuffer_((*DsdBufferPptr)->Length) ACPI_EVAL_OUTPUT_BUFFER UNALIGNED** DsdBufferPptr);
+    _Outptr_result_bytebuffer_maybenull_((*DsdBufferPptr)->Length) ACPI_EVAL_OUTPUT_BUFFER UNALIGNED** DsdBufferPptr);
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 NTSTATUS
@@ -200,14 +202,22 @@ AcpiQueryDsm(
 
 _IRQL_requires_max_(APC_LEVEL)
 NTSTATUS
+AcpiEvaluateMethod(
+    _In_ DEVICE_OBJECT* PdoPtr,
+    _In_reads_bytes_(InputBufferSize) ACPI_EVAL_INPUT_BUFFER* InputBufferPtr,
+    _In_ UINT32 InputBufferSize,
+    _Outptr_result_bytebuffer_maybenull_((*ReturnBufferPptr)->Length) ACPI_EVAL_OUTPUT_BUFFER UNALIGNED** ReturnBufferPptr);
+
+_IRQL_requires_max_(APC_LEVEL)
+NTSTATUS
 AcpiExecuteDsmFunction(
     _In_ DEVICE_OBJECT* PdoPtr,
     _In_reads_bytes_(sizeof(GUID)) const GUID* GuidPtr,
     _In_ UINT32 RevisionId,
     _In_ UINT32 FunctionIdx,
-    _In_opt_ ACPI_METHOD_ARGUMENT* FunctionArgumentsPtr,
+    _In_reads_bytes_(FunctionArgumentsSize) ACPI_METHOD_ARGUMENT* FunctionArgumentsPtr,
     _In_ USHORT FunctionArgumentsSize,
-    _Outptr_opt_result_bytebuffer_((*ReturnBufferPptr)->Length) ACPI_EVAL_OUTPUT_BUFFER UNALIGNED** ReturnBufferPptr);
+    _Outptr_opt_result_bytebuffer_maybenull_((*ReturnBufferPptr)->Length) ACPI_EVAL_OUTPUT_BUFFER UNALIGNED** ReturnBufferPptr);
 
 _IRQL_requires_same_
 NTSTATUS

--- a/drivers/net/dwc_eqos/_acpiutil.cpp
+++ b/drivers/net/dwc_eqos/_acpiutil.cpp
@@ -1,0 +1,2 @@
+#include "precomp.h"
+#include <acpiutil.cpp>

--- a/drivers/net/dwc_eqos/device.h
+++ b/drivers/net/dwc_eqos/device.h
@@ -3,7 +3,23 @@ Device behavior. Includes adapter and interrupt since they are 1:1 with the devi
 */
 #pragma once
 
-struct DeviceContext;
+struct DeviceContext; // Multi-queue: change to DeviceQueueContext.
+
+// Information about the device provided to the queues.
+struct DeviceConfig
+{
+    bool txCoeSel;      // MAC_HW_Feature0\TXCOESEL (hardware support for tx checksum offload).
+    bool rxCoeSel;      // MAC_HW_Feature0\RXCOESEL (hardware support for rx checksum offload).
+    bool pblX8;         // _DSD\snps,pblx8 (default = 1).
+    UINT8 pbl;          // _DSD\snps,pbl (default = 8).
+    UINT8 txPbl;        // _DSD\snps,txpbl (default = pbl; effect depends on pblX8).
+    UINT8 rxPbl;        // _DSD\snps,rxpbl (default = pbl; effect depends on pblX8).
+    bool fixed_burst;   // _DSD\snps,fixed-burst (default = 0).
+    bool mixed_burst;   // _DSD\snps,mixed-burst (default = 1).
+    UINT8 wr_osr_lmt;   // AXIC\snps,wr_osr_lmt (default = 4).
+    UINT8 rd_osr_lmt;   // AXIC\snps,rd_osr_lmt (default = 8).
+    UINT8 blen : 7;     // AXIC\snps,blen bitmask of 7 booleans 4..256 (default = 4, 8, 16).
+};
 
 // Referenced in driver.cpp DriverEntry.
 // Called by WDF.

--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -5,7 +5,6 @@
 /*
 TODO list:
 - Support for 10/100 Mbps modes (requires ACPI support).
-- Use ACPI to get AXI configuration (and/or tune AXI config).
 - Jumbo frames.
 - Receive queue memory optimization?
 - Configuration in registry (e.g. flow control).

--- a/drivers/net/dwc_eqos/dwc_eqos.vcxproj
+++ b/drivers/net/dwc_eqos/dwc_eqos.vcxproj
@@ -16,12 +16,14 @@
     <ClCompile Include="queue_common.cpp" />
     <ClCompile Include="rxqueue.cpp" />
     <ClCompile Include="txqueue.cpp" />
+    <ClCompile Include="_acpiutil.cpp" />
     <ClCompile Include="_precomp.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\include\acpiutil.hpp" />
     <ClInclude Include="device.h" />
     <ClInclude Include="dwc_eqos_perf_data.h" />
     <ClInclude Include="queue_common.h" />
@@ -92,6 +94,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>../../include;../../shared;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -116,6 +119,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>../../include;../../shared;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/drivers/net/dwc_eqos/dwc_eqos.vcxproj.filters
+++ b/drivers/net/dwc_eqos/dwc_eqos.vcxproj.filters
@@ -44,6 +44,9 @@
     <ClInclude Include="dwc_eqos_perf_data.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\acpiutil.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="device.cpp">
@@ -62,6 +65,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="queue_common.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="_acpiutil.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/drivers/net/dwc_eqos/queue_common.h
+++ b/drivers/net/dwc_eqos/queue_common.h
@@ -7,9 +7,6 @@ UINT32 constexpr QueueDescriptorSize = 64; // 64 == sizeof(TxDescriptor) == size
 UINT32 constexpr QueueDescriptorMinCount = PAGE_SIZE / QueueDescriptorSize;
 UINT32 constexpr QueueDescriptorMaxCount = 0x400;
 
-bool constexpr QueueBurstLengthX8 = true;
-UINT32 constexpr QueueBurstLength = 64u / (QueueBurstLengthX8 ? 8 : 1); // TODO: load from ACPI?
-
 // Alignment is mainly to make sure the allocation does not cross a 4GB boundary,
 // but it also simplifies the QueueDescriptorAddressToIndex implementation.
 auto const QueueDescriptorAlignment = QueueDescriptorMaxCount * QueueDescriptorSize;

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -857,24 +857,22 @@ union DmaSysBusMode_t
     UINT32 Value32;
     struct
     {
-        UINT32 FixedBurst : 1; // FB - Fixed Burst Length
-        UINT32 BurstLength4 : 1; // BLEN4 - AXI Burst Length 4
-        UINT32 BurstLength8 : 1; // BLEN8 - AXI Burst Length 8
-        UINT32 BurstLength16 : 1; // BLEN16 - AXI Burst Length 16
-        UINT32 Reserved4 : 6;
-        UINT32 AutoAxiLpi : 1; // AAL - Auto AXI LPI
-        UINT32 Reserved11 : 1;
-        UINT32 AddressAlignedBeats : 1; // AAL - Address Aligned Beats
-        UINT32 Reserved13 : 1;
-        UINT32 Reserved14 : 1; // mixed-burst?
-        UINT32 Reserved15 : 1;
+        UINT8 FixedBurst : 1; // FB - 0 = mixed-burst, 1 = fixed-burst
+        UINT8 BurstLengths : 7; // BLEN4 .. BLEN256 - AXI Burst Length enable bits
+        UINT8 Reserved4 : 2;
+        UINT8 AutoAxiLpi : 1; // AAL - Auto AXI LPI
+        UINT8 Reserved11 : 1;
+        UINT8 AddressAlignedBeats : 1; // AAL - Address Aligned Beats
+        UINT8 Reserved13 : 1;
+        UINT8 Reserved14 : 1; // ??? NetBSD sets this to 1 for mixed-burst.
+        UINT8 Reserved15 : 1;
 
-        UINT32 AxiMaxReadOutstanding : 4; // RD_OSR_LMT - AXI Maximum Read Outstanding Request Limit
-        UINT32 Reserved20 : 4;
-        UINT32 AxiMaxWriteOutstanding : 4; // WR_OSR_LMT - AXI Maximum Write Outstanding Request Limit
-        UINT32 Reserved28 : 2;
-        UINT32 UnlockOnPacket : 1; // LPI_XIT_PKT - Unlock on Magic/Remote Wake-up Packet
-        UINT32 EnableLpi : 1; // EN_LPI - Enable Low Power Interface (LPI)
+        UINT8 AxiMaxReadOutstanding : 4; // RD_OSR_LMT - AXI Maximum Read Outstanding Request Limit
+        UINT8 Reserved20 : 4;
+        UINT8 AxiMaxWriteOutstanding : 4; // WR_OSR_LMT - AXI Maximum Write Outstanding Request Limit
+        UINT8 Reserved28 : 2;
+        UINT8 UnlockOnPacket : 1; // LPI_XIT_PKT - Unlock on Magic/Remote Wake-up Packet
+        UINT8 EnableLpi : 1; // EN_LPI - Enable Low Power Interface (LPI)
     };
 };
 

--- a/drivers/net/dwc_eqos/rxqueue.h
+++ b/drivers/net/dwc_eqos/rxqueue.h
@@ -4,6 +4,7 @@ Receive queue behavior. Similar to the transmit queue.
 #pragma once
 
 struct DeviceContext;
+struct DeviceConfig;
 struct ChannelRegisters;
 auto constexpr RxBufferSize = 2048u;
 
@@ -13,6 +14,7 @@ _IRQL_requires_(PASSIVE_LEVEL)
 NTSTATUS
 RxQueueCreate(
     _Inout_ DeviceContext* deviceContext,
+    _In_ DeviceConfig const& deviceConfig,
     _Inout_ NETRXQUEUE_INIT* queueInit,
     _In_ WDFDMAENABLER dma,
     _Inout_ ChannelRegisters* channelRegs);

--- a/drivers/net/dwc_eqos/txqueue.h
+++ b/drivers/net/dwc_eqos/txqueue.h
@@ -4,6 +4,7 @@ Transmit queue behavior. Similar to the receive queue.
 #pragma once
 
 struct DeviceContext;
+struct DeviceConfig;
 struct ChannelRegisters;
 struct MtlQueueRegisters;
 
@@ -13,8 +14,8 @@ _IRQL_requires_(PASSIVE_LEVEL)
 NTSTATUS
 TxQueueCreate(
     _Inout_ DeviceContext* deviceContext,
+    _In_ DeviceConfig const& deviceConfig,
     _Inout_ NETTXQUEUE_INIT* queueInit,
     _In_ WDFDMAENABLER dma,
     _Inout_ ChannelRegisters* channelRegs,
-    _Inout_ MtlQueueRegisters* mtlRegs,
-    bool checksumOffloadEnabled);
+    _Inout_ MtlQueueRegisters* mtlRegs);

--- a/drivers/shared/acpiutil.cpp
+++ b/drivers/shared/acpiutil.cpp
@@ -21,13 +21,7 @@
 //
 
 #include <Ntddk.h>
-
-extern "C" {
-    #include <acpiioct.h>
-    #include <initguid.h>
-} // extern "C"
-
-#include "acpiutil.hpp"
+#include <acpiutil.hpp>
 
 #define ASSERT_MAX_IRQL(IRQL) NT_ASSERT(KeGetCurrentIrql() <= (IRQL))
 
@@ -90,18 +84,10 @@ AcpiFormatDsmFunctionInputBuffer(
     _In_ const GUID* GuidPtr,
     _In_ UINT32 RevisionId,
     _In_ UINT32 FunctionIdx,
-    _In_ ACPI_METHOD_ARGUMENT* FunctionArgumentsPtr,
+    _In_reads_bytes_(FunctionArgumentsSize) ACPI_METHOD_ARGUMENT* FunctionArgumentsPtr,
     _In_ USHORT FunctionArgumentsSize,
     _Outptr_result_bytebuffer_(*InputBufferSizePtr) ACPI_EVAL_INPUT_BUFFER_COMPLEX** InputBufferPptr,
     _Out_ UINT32* InputBufferSizePtr);
-
-_IRQL_requires_max_(APC_LEVEL)
-NTSTATUS
-AcpiEvaluateMethod(
-    _In_ DEVICE_OBJECT* PdoPtr,
-    _In_reads_bytes_(InputBufferSize) ACPI_EVAL_INPUT_BUFFER* InputBufferPtr,
-    _In_ UINT32 InputBufferSize,
-    _Outptr_result_bytebuffer_((*ReturnBufferPptr)->Length) ACPI_EVAL_OUTPUT_BUFFER UNALIGNED** ReturnBufferPptr);
 
 //
 // Internal Enumeration
@@ -565,7 +551,8 @@ AcpiSendIoctlSynchronously(
     irpPtr->IoStatus.Information = 0;
     irpPtr->UserBuffer = nullptr;
 
-    IO_STACK_LOCATION* irpStackPtr = IoGetNextIrpStackLocation(irpPtr);
+    IO_STACK_LOCATION* irpStackPtr;
+    irpStackPtr = IoGetNextIrpStackLocation(irpPtr);
     NT_ASSERT(irpStackPtr != nullptr);
     irpStackPtr->MajorFunction = IRP_MJ_DEVICE_CONTROL;
     irpStackPtr->Parameters.DeviceIoControl.IoControlCode = IoControlCode;
@@ -981,7 +968,8 @@ AcpiFormatDsmFunctionInputBuffer(
     //
     // Argument 0: UUID
     //
-    ACPI_METHOD_ARGUMENT UNALIGNED* argumentPtr = &inputBufferPtr->Argument[0];
+    ACPI_METHOD_ARGUMENT UNALIGNED* argumentPtr;
+    argumentPtr = &inputBufferPtr->Argument[0];
     ACPI_METHOD_SET_ARGUMENT_BUFFER(argumentPtr, GuidPtr, sizeof(GUID));
 
     //


### PR DESCRIPTION
Changes to acpiutil:

- `acpiutil.hpp` depends on definitions from `acpiioct.h`, so `#include` it.
- Fix code analysis warnings about SAL annotations.
- Make `AcpiEvaluateMethod` be public.
- Fix C++ conformance issues with goto jumping past variable initialization.

Changes to driver:

- Define a DeviceConfig struct with all of the configuration information.
- Pass DeviceConfig to queues.
- Queues use DeviceConfig instead of constants.
- Initialize DeviceConfig based on feature registers and ACPI.

Notes:

- Current ACPI sets mixed-burst=1, tso=1, wr_osr_lmt=4, rd_osr_lmt=8, blen=16,8,4.
- NetBSD driver references other settings that are not present in the current ACPI, and sets defaults for them: pbl=8, txpbl=8, rxpbl=8, fixed-burst=0.
- I invented a new value `pblx8` (default = 1) to control whether the X8 flag is set. Existing code assumes that it is set.
- I don't use the `tso` value for anything. I assume it is to enable/disable TCP segmentation offload, which seems more appropriate to configure in the registry.
- The docs say that mixed-burst=1 should translate into FB=0 (same as fixed-burst=0), but the NetBSD driver translates mixed-burst=1 into Reserved14=1. I'll keep that behavior since it doesn't seem to cause any harm.