### PR TITLE
dwc_eqos - change tx_clock for 10/100 support

### DIFF
--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -4,7 +4,7 @@
 
 /*
 TODO list:
-- Support for 10/100 Mbps modes (requires ACPI support).
+- Use ACPI DSM to change TX_CLK instead of hard-coding clock address in driver.
 - Jumbo frames.
 - Receive queue memory optimization?
 - Configuration in registry (e.g. flow control).

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -574,7 +574,7 @@ union MacConfiguration_t
         UINT32 EnableCarrierSenseBeforeTransmit : 1;
         UINT32 LoopbackMode : 1;
         UINT32 FullDuplex : 1;
-        PortSelectSpeed_t PortSelectSpeed : 2;
+        PortSelectSpeed_t PortSelectSpeed : 2; // Combines PS and FES.
 
         UINT32 JumboPacketEnable : 1;
         UINT32 JabberDisable : 1;


### PR DESCRIPTION
Change the tx_clock when link speed changes so we can support 10 and 100 speeds.

TODO: Use ACPI DSM instead of directly accessing clock.