### PR TITLE
dwc_eqos - use ACPI DSM to change TX_CLOCK

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository contains drivers for RK35xx-based platforms, with a focus on RK3
 |Multimedia codecs||🔴 Not working||
 |DSI||🔴 Not working||
 |CSI||🔴 Not working||
-|GMAC Ethernet|[dwc_eqos](drivers/net/dwc_eqos)|🟡 Partially working|1000Mbps only (gigabit Ethernet only - 10/100 not yet supported)|
+|GMAC Ethernet|[dwc_eqos](drivers/net/dwc_eqos)|🟢 Working|Requires latest UEFI (edk2-rk3588 master 2024/01/03 or later).<br> Note that this driver supports the on-chip Ethernet (e.g. it supports the 1GB Ethernet port on Opi5) but does not support the separate Ethernet chip that is added to some higher-tier boards (e.g. it does not support the 2.5GB Ethernet ports on Opi5+).
 |UART||🔴 Not working|No OS driver but debugging does work on UART2, being configured by UEFI.|
 |GPIO|[rk3xgpio](https://github.com/worproject/Rockchip-Windows-Drivers/tree/master/drivers/gpio)|🟢 Working||
 |I2C|[rk3xi2c](https://github.com/worproject/Rockchip-Windows-Drivers/tree/master/drivers/i2c)|🟢 Working||

--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -3,11 +3,11 @@
 #include "trace.h"
 
 /*
-TODO list:
-- Use ACPI DSM to change TX_CLK instead of hard-coding clock address in driver.
+Possible areas for improvement:
+- Run against network test suites and fix any issues.
+- Interrupt moderation and/or other CPU usage improvements.
 - Jumbo frames.
-- Receive queue memory optimization?
-- Configuration in registry (e.g. flow control).
+- Configuration in registry (e.g. flow control, speed, duplex).
 - Tx segmentation offload.
 - Rx segmentation offload.
 - Wake-on-LAN.


### PR DESCRIPTION
- Remove hard-coded TX_CLOCK register management.
- Replace direct TX_CLOCK register update with ACPI DSM.
- Add guard against running UpdateLinkState work item more than once at
  a time.
- Update readme.