### PR TITLE
dwc_eqos - vlan, flow, INF config options

### DIFF
--- a/drivers/net/dwc_eqos/descriptors.h
+++ b/drivers/net/dwc_eqos/descriptors.h
@@ -168,6 +168,7 @@ struct TxDescriptorContext
     UINT8 OneStepEnable : 1; // OSTC
     UINT8 Reserved28 : 2;
     UINT8 ContextType : 1; // CTXT = 1
+    UINT8 Own : 1; // OWN
 
 #if DBG
     UINT32 FragmentIndex;

--- a/drivers/net/dwc_eqos/device.h
+++ b/drivers/net/dwc_eqos/device.h
@@ -19,6 +19,8 @@ struct DeviceConfig
     UINT8 wr_osr_lmt;   // AXIC\snps,wr_osr_lmt (default = 4).
     UINT8 rd_osr_lmt;   // AXIC\snps,rd_osr_lmt (default = 8).
     UINT8 blen : 7;     // AXIC\snps,blen bitmask of 7 booleans 4..256 (default = 4, 8, 16).
+    bool txFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
+    bool rxFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
 };
 
 // Referenced in driver.cpp DriverEntry.
@@ -66,5 +68,4 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 DeviceAddStatisticsTxQueue(
     _Inout_ DeviceContext* context,
-    UINT32 ownDescriptors,
     UINT32 doneFragments);

--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -1,15 +1,14 @@
 #include "precomp.h"
-#include "device.h" // DeviceAdd
+#include "device.h"
 #include "trace.h"
 
 /*
 Possible areas for improvement:
-- Run against network test suites and fix any issues.
 - Jumbo frames.
-- Configuration in registry (e.g. flow control, speed, duplex).
 - Tx segmentation offload.
-- Wake-on-LAN.
-- ARP offload.
+- Run against network test suites and fix any issues.
+- Power control, wake-on-LAN, ARP offload.
+- Configure speed, duplex in Ndi\params.
 - Multi-queue support?
 */
 

--- a/drivers/net/dwc_eqos/dwc_eqos.inf
+++ b/drivers/net/dwc_eqos/dwc_eqos.inf
@@ -77,52 +77,44 @@ HKR, Ndi\Interfaces, LowerRange, 0, "ethernet"
 
 [DWCEQOS_AddReg_Ndi_params]
 
-HKR, Ndi\params\NetworkAddress, ParamDesc, 0, %NetworkAddress%
-HKR, Ndi\params\NetworkAddress, type,      0, "edit"
-HKR, Ndi\params\NetworkAddress, default,   0, ""
-HKR, Ndi\params\NetworkAddress, LimitText, 0, "12"
-HKR, Ndi\params\NetworkAddress, UpperCase, 0, "1"
-HKR, Ndi\params\NetworkAddress, Optional,  0, "1"
+HKR, Ndi\params\NetworkAddress,                  ParamDesc,      0, %NetworkAddress%
+HKR, Ndi\params\NetworkAddress,                  type,           0, "edit"
+HKR, Ndi\params\NetworkAddress,                  default,        0, ""
+HKR, Ndi\params\NetworkAddress,                  LimitText,      0, "12"
+HKR, Ndi\params\NetworkAddress,                  UpperCase,      0, "1"
+HKR, Ndi\params\NetworkAddress,                  Optional,       0, "1"
 
-HKR, Ndi\params\*IPChecksumOffloadIPv4,          ParamDesc,      0,  %IPChksumOffV4%
-HKR, Ndi\params\*IPChecksumOffloadIPv4,          default,        0,  "3"
-HKR, Ndi\params\*IPChecksumOffloadIPv4,          type,           0,  "enum"
-HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "0",            0,  %Disabled%
-HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "1",            0,  %TxEnabled%
-HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "2",            0,  %RxEnabled%
-HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "3",            0,  %RxTxEnabled%
+HKR, Ndi\params\*FlowControl,                    ParamDesc,      0,  %FlowControl%
+HKR, Ndi\params\*FlowControl,                    default,        0,  "3"
+HKR, Ndi\params\*FlowControl,                    type,           0,  "enum"
+HKR, Ndi\params\*FlowControl\enum,               "0",            0,  %Disabled%
+HKR, Ndi\params\*FlowControl\enum,               "1",            0,  %TxEnabled%
+HKR, Ndi\params\*FlowControl\enum,               "2",            0,  %RxEnabled%
+HKR, Ndi\params\*FlowControl\enum,               "3",            0,  %TxRxEnabled%
 
-HKR, Ndi\params\*TCPChecksumOffloadIPv4,         ParamDesc,      0,  %TCPChksumOffV4%
-HKR, Ndi\params\*TCPChecksumOffloadIPv4,         default,        0,  "3"
-HKR, Ndi\params\*TCPChecksumOffloadIPv4,         type,           0,  "enum"
-HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "0",            0,  %Disabled%
-HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "1",            0,  %TxEnabled%
-HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "2",            0,  %RxEnabled%
-HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "3",            0,  %RxTxEnabled%
+HKR, Ndi\Params\*PriorityVLANTag,                ParamDesc,      0,  %PriorityVlanTag%
+HKR, Ndi\Params\*PriorityVLANTag,                Default,        0,  "3"
+HKR, Ndi\Params\*PriorityVLANTag,                Type,           0,  "enum"
+HKR, Ndi\Params\*PriorityVLANTag\enum,           "0",            0,  %Disabled%
+HKR, Ndi\Params\*PriorityVLANTag\enum,           "1",            0,  %PriorityEnabled%
+HKR, Ndi\Params\*PriorityVLANTag\enum,           "2",            0,  %VlanEnabled%
+HKR, Ndi\Params\*PriorityVLANTag\enum,           "3",            0,  %PriorityVlanEnabled%
 
-HKR, Ndi\params\*UDPChecksumOffloadIPv4,         ParamDesc,      0,  %UDPChksumOffV4%
-HKR, Ndi\params\*UDPChecksumOffloadIPv4,         default,        0,  "3"
-HKR, Ndi\params\*UDPChecksumOffloadIPv4,         type,           0,  "enum"
-HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "0",            0,  %Disabled%
-HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "1",            0,  %TxEnabled%
-HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "2",            0,  %RxEnabled%
-HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "3",            0,  %RxTxEnabled%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4,      ParamDesc,      0,  %TCPUDPChecksumOffloadIPv4%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4,      default,        0,  "3"
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4,      type,           0,  "enum"
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4\enum, "0",            0,  %Disabled%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4\enum, "1",            0,  %TxEnabled%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4\enum, "2",            0,  %RxEnabled%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4\enum, "3",            0,  %TxRxEnabled%
 
-HKR, Ndi\params\*TCPChecksumOffloadIPv6,         ParamDesc,      0,  %TCPChksumOffV6%
-HKR, Ndi\params\*TCPChecksumOffloadIPv6,         default,        0,  "3"
-HKR, Ndi\params\*TCPChecksumOffloadIPv6,         type,           0,  "enum"
-HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "0",            0,  %Disabled%
-HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "1",            0,  %TxEnabled%
-HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "2",            0,  %RxEnabled%
-HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "3",            0,  %RxTxEnabled%
-
-HKR, Ndi\params\*UDPChecksumOffloadIPv6,         ParamDesc,      0,  %UDPChksumOffV6%
-HKR, Ndi\params\*UDPChecksumOffloadIPv6,         default,        0,  "3"
-HKR, Ndi\params\*UDPChecksumOffloadIPv6,         type,           0,  "enum"
-HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "0",            0,  %Disabled%
-HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "1",            0,  %TxEnabled%
-HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "2",            0,  %RxEnabled%
-HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "3",            0,  %RxTxEnabled%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6,      ParamDesc,      0,  %TCPUDPChecksumOffloadIPv6%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6,      default,        0,  "3"
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6,      type,           0,  "enum"
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6\enum, "0",            0,  %Disabled%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6\enum, "1",            0,  %TxEnabled%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6\enum, "2",            0,  %RxEnabled%
+HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6\enum, "3",            0,  %TxRxEnabled%
 
 [DWCEQOS_Device.NT.Services]
 AddService = %ServiceName%, 2, DWCEQOS_AddService, DWCEQOS_AddService_EventLog
@@ -153,19 +145,21 @@ KmdfLibraryVersion = $KMDFVERSION$
 
 [Strings]
 ProviderName        = "Open Source"
-NetworkAddress      = "Network Address"
 RKCP                = "Rockchip"
 DWCEQOS.DeviceDesc  = "Synopsys DesignWare Ethernet Quality of Service (GMAC)"
 DWCEQOS.ServiceDesc = "DesignWare Ethernet"
-IPChksumOffV4       = "IPv4 Checksum Offload"
-TCPChksumOffV4      = "TCP Checksum Offload (IPv4)"
-UDPChksumOffV4      = "UDP Checksum Offload (IPv4)"
-TCPChksumOffV6      = "TCP Checksum Offload (IPv6)"
-UDPChksumOffV6      = "UDP Checksum Offload (IPv6)"
+NetworkAddress      = "Network Address"
+FlowControl         = "Flow Control"
+PriorityVlanTag     = "Packet Priority & VLAN"
+TCPUDPChecksumOffloadIPv4 = "TCP/UDP Checksum Offload (IPv4)"
+TCPUDPChecksumOffloadIPv6 = "TCP/UDP Checksum Offload (IPv6)"
 Disabled            = "Disabled"
 TxEnabled           = "Tx Enabled"
 RxEnabled           = "Rx Enabled"
-RxTxEnabled         = "Rx & Tx Enabled"
+TxRxEnabled         = "Tx and Rx Enabled"
+PriorityEnabled     = "Packet Priority Enabled"
+VlanEnabled         = "VLAN Enabled"
+PriorityVlanEnabled = "Packet Priority & VLAN Enabled"
 
 ; Not localized
 ServiceName = "dwc_eqos"

--- a/drivers/net/dwc_eqos/dwc_eqos_perf.man
+++ b/drivers/net/dwc_eqos/dwc_eqos_perf.man
@@ -454,19 +454,10 @@
             />
           <counter
             detailLevel="standard"
-            field="TxOwnDescriptors"
-            id="9"
-            name="TxOwnDescriptors"
-            nameID="278"
-            type="perf_counter_rawcount"
-            uri="uri:opensource/dwc_eqos/perf/debug/TxOwnDescriptors"
-            />
-          <counter
-            detailLevel="standard"
             field="TxDoneFragments"
-            id="10"
+            id="9"
             name="TxDoneFragments"
-            nameID="280"
+            nameID="278"
             type="perf_counter_rawcount"
             uri="uri:opensource/dwc_eqos/perf/debug/TxDoneFragments"
             />

--- a/drivers/net/dwc_eqos/dwc_eqos_perf_data.h
+++ b/drivers/net/dwc_eqos/dwc_eqos_perf_data.h
@@ -30,7 +30,6 @@ struct PERF_DEBUG_DATA
     UINT32 DpcFatalBusError;
     UINT32 RxOwnDescriptors;
     UINT32 RxDoneFragments;
-    UINT32 TxOwnDescriptors;
     UINT32 TxDoneFragments;
 };
 

--- a/drivers/net/dwc_eqos/precomp.h
+++ b/drivers/net/dwc_eqos/precomp.h
@@ -8,6 +8,7 @@
 #pragma warning(pop)
 
 #include <netadaptercx.h>
+#include <net/ieee8021q.h>
 #include <net/logicaladdress.h>
 #include <net/virtualaddress.h>
 #include <net/checksum.h>

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -639,6 +639,43 @@ union MacPacketFilter_t
     };
 };
 
+enum VlanTagStripOnReceive : UINT8
+{
+    VlanTagStripOnReceive_Never,
+    VlanTagStripOnReceive_IfFilterPasses,
+    VlanTagStripOnReceive_IfFilterFails,
+    VlanTagStripOnReceive_Always,
+};
+
+union Mac_Vlan_Tag_Ctrl_t
+{
+    UINT32 Value32;
+    struct
+    {
+        UINT8 OperationBusy : 1; // OB
+        UINT8 CommandType : 1; // CT, 0 = write, 1 = read.
+        UINT8 Offset : 5; // OFS
+        UINT8 Reserved7 : 1;
+
+        UINT8 Reserved8;
+
+        UINT8 Reserved16 : 1;
+        UINT8 InverseMatchEnable : 1; // VTIM
+        UINT8 SvlanEnable : 1; // ESVL
+        UINT8 Reserved19 : 2;
+        VlanTagStripOnReceive StripOnReceive : 2; // EVLS
+        UINT8 Reserved23 : 1;
+
+        UINT8 RxStatusEnable : 1; // EVLRXS
+        UINT8 HashTableMatchEnable : 1; // VTHM
+        UINT8 DoubleVlanEnable : 1; // EDVLP
+        UINT8 InnerEnable : 1; // ERIVLT
+        VlanTagStripOnReceive InnerStripOnReceive : 2; // EIVLS
+        UINT8 Reserved30 : 1;
+        UINT8 InnerRxStatusEnable : 1; // EIVLRXS
+    };
+};
+
 union MacInterruptStatus_t
 {
     UINT32 Value32;
@@ -924,7 +961,7 @@ struct MacRegisters
     // This register is the redefined format of the MAC VLAN Tag Register. It is used
     // for indirect addressing. It contains the address offset, command type and Busy
     // Bit for CSR access of the Per VLAN Tag registers.
-    ULONG Mac_Vlan_Tag_Ctrl;
+    Mac_Vlan_Tag_Ctrl_t Mac_Vlan_Tag_Ctrl;
 
     // MAC_VLAN_Tag_Data @ 0x0054 = 0x0:
     // This register holds the read/write data for Indirect Access of the Per VLAN Tag


### PR DESCRIPTION
- Change checksum offload INF options from granular to combined.
- Add INF options for FlowControl, PriorityVlanTag.
- Respect INF option for FlowControl at MAC level.
- Set DisableReceiveOwn on MAC options.
- Correct Rx VLAN tag behavior: always strip tag, always copy tag to OOB.
- Correct Tx VLAN tag behavior: add tag if present in OOB.
- Stop tracking Tx-Own statistics. They don't seem useful.

The Tx VLAN tag behavior required significant refactoring of TxQueueAdvance. Previously we depended on one-to-one mapping between descriptor and fragment, but VLAN tags require context descriptors so there can now be descriptors without a matching fragment, so our descriptor drain code needs to deal with that.