### PR TITLE
rk3xi2c - Report I2C transaction status

### DIFF
--- a/drivers/i2c/rk3xi2c/rockchipi2c.c
+++ b/drivers/i2c/rk3xi2c/rockchipi2c.c
@@ -409,6 +409,8 @@ NTSTATUS i2c_xfer_single(
 		return status;
 	}
 
+	status = pDevice->transactionStatus;
+
 	return status;
 }
 


### PR DESCRIPTION
Report I2C transaction status so that I2C errors can propagate down to peripheral drivers and SPBTestTool

Test: Attempt to do transaction on non-existent I2C device. Observe STATUS_INVALID_TRANSACTION reported instead of STATUS_SUCCESS when a NACK is received on the bus