### PR TITLE
i2s: read tx/rx route from ACPI

### DIFF
--- a/drivers/audio/csaudiork3x/Source/Utilities/adsp.h
+++ b/drivers/audio/csaudiork3x/Source/Utilities/adsp.h
@@ -14,6 +14,8 @@ typedef struct _RK_TPLG {
     UINT32 tx;
     UINT32 rx;
     char audio_tplg[32];
+    UINT32 i2s_tx_route;
+    UINT32 i2s_rx_route;
 } RK_TPLG, *PRK_TPLG;
 
 typedef struct _TPLG_INFO {

--- a/drivers/audio/csaudiork3x/Source/Utilities/hw.cpp
+++ b/drivers/audio/csaudiork3x/Source/Utilities/hw.cpp
@@ -191,31 +191,35 @@ NTSTATUS CCsAudioRk3xHW::rk3x_init() {
         I2S_RXCR_VDW(16));
 
     //set path
-    i2s_update32(I2S_TXCR,
-        I2S_TXCR_PATH_MASK(0),
-        I2S_TXCR_PATH(0, 3));
-    i2s_update32(I2S_TXCR,
-        I2S_TXCR_PATH_MASK(1),
-        I2S_TXCR_PATH(1, 2));
-    i2s_update32(I2S_TXCR,
-        I2S_TXCR_PATH_MASK(2),
-        I2S_TXCR_PATH(2, 1));
-    i2s_update32(I2S_TXCR,
-        I2S_TXCR_PATH_MASK(3),
-        I2S_TXCR_PATH(3, 0));
+    if (this->rkTPLG.i2s_tx_route) {
+        i2s_update32(I2S_TXCR,
+            I2S_TXCR_PATH_MASK(0),
+            I2S_TXCR_PATH(0, (this->rkTPLG.i2s_tx_route >> 12) & 0xf));
+        i2s_update32(I2S_TXCR,
+            I2S_TXCR_PATH_MASK(1),
+            I2S_TXCR_PATH(1, (this->rkTPLG.i2s_tx_route >> 8) & 0xf));
+        i2s_update32(I2S_TXCR,
+            I2S_TXCR_PATH_MASK(2),
+            I2S_TXCR_PATH(2, (this->rkTPLG.i2s_tx_route >> 4) & 0xf));
+        i2s_update32(I2S_TXCR,
+            I2S_TXCR_PATH_MASK(3),
+            I2S_TXCR_PATH(3, (this->rkTPLG.i2s_tx_route >> 0) & 0xf));
+    }
 
-    i2s_update32(I2S_RXCR,
-        I2S_RXCR_PATH_MASK(0),
-        I2S_RXCR_PATH(0, 1));
-    i2s_update32(I2S_RXCR,
-        I2S_RXCR_PATH_MASK(1),
-        I2S_RXCR_PATH(1, 3));
-    i2s_update32(I2S_RXCR,
-        I2S_RXCR_PATH_MASK(2),
-        I2S_RXCR_PATH(2, 2));
-    i2s_update32(I2S_RXCR,
-        I2S_RXCR_PATH_MASK(3),
-        I2S_RXCR_PATH(3, 0));
+    if (this->rkTPLG.i2s_rx_route) {
+        i2s_update32(I2S_RXCR,
+            I2S_RXCR_PATH_MASK(0),
+            I2S_RXCR_PATH(0, (this->rkTPLG.i2s_rx_route >> 12) & 0xf));
+        i2s_update32(I2S_RXCR,
+            I2S_RXCR_PATH_MASK(1),
+            I2S_RXCR_PATH(1, (this->rkTPLG.i2s_rx_route >> 8) & 0xf));
+        i2s_update32(I2S_RXCR,
+            I2S_RXCR_PATH_MASK(2),
+            I2S_RXCR_PATH(2, (this->rkTPLG.i2s_rx_route >> 4) & 0xf));
+        i2s_update32(I2S_RXCR,
+            I2S_RXCR_PATH_MASK(3),
+            I2S_RXCR_PATH(3, (this->rkTPLG.i2s_rx_route >> 0) & 0xf));
+    }
 
     return STATUS_SUCCESS;
 #else

--- a/drivers/audio/rk3xi2sbus/rk-tplg.cpp
+++ b/drivers/audio/rk3xi2sbus/rk-tplg.cpp
@@ -155,6 +155,12 @@ GetRKTplg(
 			else if (CHECK_STR(dsdParameterName, "rockchip,rx")) {
 				copyDSDParamNum(dsdParameterData, &rkTplg->rx);
 			}
+			else if (CHECK_STR(dsdParameterName, "rockchip,i2s-tx-route")) {
+				copyDSDParamNum(dsdParameterData, &rkTplg->i2s_tx_route);
+			}
+			else if (CHECK_STR(dsdParameterName, "rockchip,i2s-rx-route")) {
+				copyDSDParamNum(dsdParameterData, &rkTplg->i2s_rx_route);
+			}
 		}
 	}
 

--- a/drivers/audio/rk3xi2sbus/rk-tplg.h
+++ b/drivers/audio/rk3xi2sbus/rk-tplg.h
@@ -10,6 +10,8 @@ typedef struct _RK_TPLG {
 	UINT32 tx;
 	UINT32 rx;
 	char audio_tplg[32];
+	UINT32 i2s_tx_route;
+	UINT32 i2s_rx_route;
 } RK_TPLG, *PRK_TPLG;
 
 NTSTATUS GetRKTplg(WDFDEVICE FxDevice, RK_TPLG *rkTplg);


### PR DESCRIPTION
Read tx/rx route from ACPI as optional properties and only program the route if these properties are present.

Do not program these outside the Orange Pi 5, as most devices use the default route.

Tested on Orange Pi 5 Plus and verified audio functional without the route set