### PR TITLE
dwc_eqos - jumbo packets up to 4088

### DIFF
--- a/drivers/net/dwc_eqos/device.h
+++ b/drivers/net/dwc_eqos/device.h
@@ -21,6 +21,7 @@ struct DeviceConfig
     UINT8 blen : 7;     // AXIC\snps,blen bitmask of 7 booleans 4..256 (default = 4, 8, 16).
     bool txFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
     bool rxFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
+    UINT16 jumboFrame;  // Adapter configuration (Ndi\params\*JumboFrame). 1514..4088
 };
 
 // Referenced in driver.cpp DriverEntry.

--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -4,7 +4,8 @@
 
 /*
 Possible areas for improvement:
-- Jumbo frames.
+- 9014-byte jumbo frames (current limit is 4088).
+  This probably requires custom receive buffer management.
 - Tx segmentation offload.
 - Run against network test suites and fix any issues.
 - Power control, wake-on-LAN, ARP offload.

--- a/drivers/net/dwc_eqos/dwc_eqos.inf
+++ b/drivers/net/dwc_eqos/dwc_eqos.inf
@@ -84,6 +84,12 @@ HKR, Ndi\params\NetworkAddress,                  LimitText,      0, "12"
 HKR, Ndi\params\NetworkAddress,                  UpperCase,      0, "1"
 HKR, Ndi\params\NetworkAddress,                  Optional,       0, "1"
 
+HKR, Ndi\params\*JumboPacket,                    ParamDesc,      0, %JumboPacket%
+HKR, Ndi\params\*JumboPacket,                    type,           0, "int"
+HKR, Ndi\params\*JumboPacket,                    default,        0, "1514"
+HKR, Ndi\params\*JumboPacket,                    min,            0, "1514"
+HKR, Ndi\params\*JumboPacket,                    max,            0, "4088" ; TODO: 9014-byte jumbo frames.
+
 HKR, Ndi\params\*FlowControl,                    ParamDesc,      0,  %FlowControl%
 HKR, Ndi\params\*FlowControl,                    default,        0,  "3"
 HKR, Ndi\params\*FlowControl,                    type,           0,  "enum"
@@ -149,6 +155,7 @@ RKCP                = "Rockchip"
 DWCEQOS.DeviceDesc  = "Synopsys DesignWare Ethernet Quality of Service (GMAC)"
 DWCEQOS.ServiceDesc = "DesignWare Ethernet"
 NetworkAddress      = "Network Address"
+JumboPacket         = "Jumbo Packet"
 FlowControl         = "Flow Control"
 PriorityVlanTag     = "Packet Priority & VLAN"
 TCPUDPChecksumOffloadIPv4 = "TCP/UDP Checksum Offload (IPv4)"

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -647,7 +647,7 @@ enum VlanTagStripOnReceive : UINT8
     VlanTagStripOnReceive_Always,
 };
 
-union Mac_Vlan_Tag_Ctrl_t
+union MacVlanTagCtrl_t
 {
     UINT32 Value32;
     struct
@@ -930,6 +930,20 @@ union MacTxFlowCtrl_t
     };
 };
 
+union MacWatchdogTimeout_t
+{
+    UINT32 Value32;
+    struct
+    {
+        UINT8 WatchdogTimeout; // WTO; effective timeout is (WatchdogTimeout * 1024) + 2048 bytes.
+
+        UINT8 ProgrammableWatchdogEnable : 1; // PWE
+        UINT8 Reserved9 : 7;
+        UINT8 Reserved16 : 8;
+        UINT8 Reserved24 : 8;
+    };
+};
+
 struct MacRegisters
 {
     // MAC_Configuration @ 0x0000 = 0x0:
@@ -949,7 +963,7 @@ struct MacRegisters
     // MAC_Watchdog_Timeout @ 0x000C = 0x0:
     // The Watchdog Timeout register controls the watchdog timeout for received
     // packets.
-    ULONG Mac_Watchdog_Timeout;
+    MacWatchdogTimeout_t Mac_Watchdog_Timeout;
 
     // MAC_Hash_Table_RegX @ 0x0010 = 0x0:
     // The Hash Table Register X contains the Xth 32 bits of the hash table.
@@ -961,7 +975,7 @@ struct MacRegisters
     // This register is the redefined format of the MAC VLAN Tag Register. It is used
     // for indirect addressing. It contains the address offset, command type and Busy
     // Bit for CSR access of the Per VLAN Tag registers.
-    Mac_Vlan_Tag_Ctrl_t Mac_Vlan_Tag_Ctrl;
+    MacVlanTagCtrl_t Mac_Vlan_Tag_Ctrl;
 
     // MAC_VLAN_Tag_Data @ 0x0054 = 0x0:
     // This register holds the read/write data for Indirect Access of the Per VLAN Tag

--- a/drivers/net/dwc_eqos/rxqueue.cpp
+++ b/drivers/net/dwc_eqos/rxqueue.cpp
@@ -120,7 +120,6 @@ RxQueueAdvance(_In_ NETPACKETQUEUE queue)
         auto const descWrite = desc.Write;
 
         // Descriptor is still owned by the DMA engine?
-        NT_ASSERT(!descWrite.Own);
         if (descWrite.Own)
         {
             /*

--- a/drivers/net/dwc_eqos/rxqueue.h
+++ b/drivers/net/dwc_eqos/rxqueue.h
@@ -6,7 +6,11 @@ Receive queue behavior. Similar to the transmit queue.
 struct DeviceContext;
 struct DeviceConfig;
 struct ChannelRegisters;
-auto constexpr RxBufferSize = 2048u;
+
+// NetAdapterCx appears to allocate fragment buffers in multiples of PAGE_SIZE,
+// so there's no reason to use a size smaller than this. 4KB buffers allow us
+// to receive jumbo packets up to 4088 bytes.
+auto constexpr RxBufferSize = 4096u;
 
 // Called by device.cpp AdapterCreateRxQueue.
 _IRQL_requires_same_


### PR DESCRIPTION
Support jumbo packets up to 4088 bytes (MTU 4074). This means raising the receive buffer size up to 4096, but since it appears that NetAdapterCx allocates buffers at page granularity anyway, I don't think this actually costs anything.

I tried to enable 9014-byte packets, but with system-managed buffering, I can't see how to specify that I want a small buffer (e.g. 2KB or 4KB) while also indicating that I might receive a large packet (e.g. 9014 bytes) -- the two sizes appear to be tied together. I think if we want 9014-byte jumbo frames, we either use 12KB receive buffers (very inefficient use of memory) or we use driver-managed receive buffers (a bit more work that I can't finish tonight). So stick with a 4088 byte limit for now.