### PR TITLE
dwc_eqos - support 9014-byte jumbo frames

### DIFF
--- a/drivers/net/dwc_eqos/device.cpp
+++ b/drivers/net/dwc_eqos/device.cpp
@@ -31,7 +31,7 @@ static auto constexpr QueuesSupported = 1u; // TODO: Support multiple queues?
 static auto constexpr InterruptLinkStatus = 0x80000000u;
 static auto constexpr InterruptChannel0StatusMask = ~InterruptLinkStatus;
 static UINT16 constexpr JumboPacketMin = 1514u;
-static UINT16 constexpr JumboPacketMax = RxBufferSize - 8u; // 8 == VLAN + CRC. TODO: 9014-byte jumbo frames.
+static UINT16 constexpr JumboPacketMax = 9014u;
 
 // D637828D-556C-4829-966A-237072F00FF1
 static GUID constexpr DsmGuid = { 0xD637828D, 0x556C, 0x4829, 0x96, 0x6A, 0x23, 0x70, 0x72, 0xF0, 0x0F, 0xF1 };
@@ -1224,8 +1224,10 @@ DevicePrepareHardware(
         NET_ADAPTER_TX_CAPABILITIES_INIT_FOR_DMA(&txCaps, &dmaCaps, QueuesSupported);
         txCaps.MaximumNumberOfFragments = QueueDescriptorMinCount - 2; // = 1 hole in the ring + 1 context descriptor.
 
-        NET_ADAPTER_RX_CAPABILITIES rxCaps; // TODO: 9014-byte jumbo frames probably require custom buffering.
-        NET_ADAPTER_RX_CAPABILITIES_INIT_SYSTEM_MANAGED_DMA(&rxCaps, &dmaCaps, RxBufferSize, QueuesSupported);
+        // TODO: Driver-managed buffering + multi-descriptor receive would
+        // reduce memory overhead of Jumbo Packets.
+        NET_ADAPTER_RX_CAPABILITIES rxCaps;
+        NET_ADAPTER_RX_CAPABILITIES_INIT_SYSTEM_MANAGED_DMA(&rxCaps, &dmaCaps, context->config.RxBufferSize(), QueuesSupported);
 
         NetAdapterSetDataPathCapabilities(context->adapter, &txCaps, &rxCaps);
 

--- a/drivers/net/dwc_eqos/device.h
+++ b/drivers/net/dwc_eqos/device.h
@@ -22,6 +22,12 @@ struct DeviceConfig
     bool txFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
     bool rxFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
     UINT16 jumboFrame;  // Adapter configuration (Ndi\params\*JumboFrame). 1514..4088
+
+    UINT16 RxBufferSize() const
+    {
+        UINT16 const frameSize = jumboFrame + 8u; // 8 = VLAN + CRC.
+        return (frameSize + 7u) & ~7u; // Round up to multiple of 8.
+    }
 };
 
 // Referenced in driver.cpp DriverEntry.

--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -4,8 +4,6 @@
 
 /*
 Possible areas for improvement:
-- 9014-byte jumbo frames (current limit is 4088).
-  This probably requires custom receive buffer management.
 - Tx segmentation offload.
 - Run against network test suites and fix any issues.
 - Power control, wake-on-LAN, ARP offload.

--- a/drivers/net/dwc_eqos/dwc_eqos.inf
+++ b/drivers/net/dwc_eqos/dwc_eqos.inf
@@ -88,7 +88,7 @@ HKR, Ndi\params\*JumboPacket,                    ParamDesc,      0, %JumboPacket
 HKR, Ndi\params\*JumboPacket,                    type,           0, "int"
 HKR, Ndi\params\*JumboPacket,                    default,        0, "1514"
 HKR, Ndi\params\*JumboPacket,                    min,            0, "1514"
-HKR, Ndi\params\*JumboPacket,                    max,            0, "4088" ; TODO: 9014-byte jumbo frames.
+HKR, Ndi\params\*JumboPacket,                    max,            0, "9014"
 
 HKR, Ndi\params\*FlowControl,                    ParamDesc,      0,  %FlowControl%
 HKR, Ndi\params\*FlowControl,                    default,        0,  "3"

--- a/drivers/net/dwc_eqos/rxqueue.h
+++ b/drivers/net/dwc_eqos/rxqueue.h
@@ -7,11 +7,6 @@ struct DeviceContext;
 struct DeviceConfig;
 struct ChannelRegisters;
 
-// NetAdapterCx appears to allocate fragment buffers in multiples of PAGE_SIZE,
-// so there's no reason to use a size smaller than this. 4KB buffers allow us
-// to receive jumbo packets up to 4088 bytes.
-auto constexpr RxBufferSize = 4096u;
-
 // Called by device.cpp AdapterCreateRxQueue.
 _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)


### PR DESCRIPTION
Enable support for 9014-byte jumbo frames.

- Update INF to allow JumboPacket up to 9014.
- Tell NetAdapterCx that the receive buffer size needs to be RoundUp8(JumboPacket + 8), where JumboPacket is set in the INF (default = min = 1514, max = 9014).
- Tell hardware that the receive buffer size is RoundUp8(JumboPacket + 8).

Note that using a full 9022-byte buffer for 1522-byte packets is sub-optimal. NetAdapterCx does not currently support multi-fragment packets if using system-managed buffering. With driver-managed buffering we could fix this, but that probably isn't worthwhile at this point.