### PR TITLE
dwc_eqos - segmentation offload and vlan fixes

### DIFF
--- a/drivers/net/dwc_eqos/AutoLogger.reg
+++ b/drivers/net/dwc_eqos/AutoLogger.reg
@@ -1,0 +1,12 @@
+﻿Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\WMI\Autologger\dwc_eqos]
+"Guid"="{3fde989c-5470-4452-8f3c-91b0584f5a75}"
+"BufferSize"=dword:00000010
+"LogFileMode"=dword:08080400
+"Start"=dword:00000001
+
+[HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\WMI\Autologger\dwc_eqos\{5d8331d3-70b3-5620-5664-db28f48a4b79}]
+"Enabled"=dword:00000001
+"EnableLevel"=dword:00000004
+"EnableFlags"=dword:00000003

--- a/drivers/net/dwc_eqos/README.md
+++ b/drivers/net/dwc_eqos/README.md
@@ -1,0 +1,48 @@
+# Synopsys DesignWare Ethernet Quality of Service (GMAC) Driver
+
+This is a driver for the Synopsys DesignWare Ethernet Quality of Service (EQoS)
+controller found in the RK35xx SoCs, supporting 1Gbps ethernet connections.
+
+## Compatibility
+
+EQoS is a configurable IP block that can be customized and added to a SoC. This
+driver has been tested only on the RK3588(s) and assumes the presence of
+optional features that may be missing on other SoCs. With minor fixes, it would
+probably work on other EQoS-based SoCs. The driver specifically checks for the
+following:
+
+- `GMAC_MAC_Version.RKVER` must be 0x51 or 0x52 (other values untested).
+- `GMAC_MAC_HW_Feature0.SAVLANINS` must be enabled (require VLAN insertion support).
+- `GMAC_MAC_HW_Feature0.RXCOESEL` and `TXCOESEL` must be enabled (require checksum offload support).
+- `GMAC_MAC_HW_Feature1.TSOEN` must be enabled (require TCP/UDP segmentation offload support).
+
+There may be other requirements that are assumed but not checked.
+
+## ACPI Configuration
+
+This driver uses ACPI properties to configure the EQoS controller's DMA behavior:
+
+- `_DSD\snps,pblx8` (default = 1): Controls the value of `GMAC_DMA_CHx_Control.PBLx8`, i.e. controls whether PBL values are treated as 1-beat units (0) or 8-beat units (1, default).
+- `_DSD\snps,pbl` (default = 8): Default value for `txpbl` and `rxpbl`.
+- `_DSD\snps,txpbl` (default = `pbl`): Controls the value of `GMAC_DMA_CHx_Tx_Control.TxPBL`, i.e. transmit programmable burst length.
+- `_DSD\snps,rxpbl` (default = `pbl`): Controls the value of `GMAC_DMA_CHx_Rx_Control.RxPBL`, i.e. receive programmable burst length.
+- `_DSD\snps,fixed-burst` (default = 0): Controls the value of `GMAC_DMA_SysBus_Mode.FB`.
+- `_DSD\snps,mixed-burst` (default = 1): Controls the value of `GMAC_DMA_SysBus_Mode.Bit14`.
+- `_DSD\snps,axi-config` (default = none): Controls the `$(AXIC)` method name to use for the remaining properties. If not present, the driver will use default values for the remaining properties. Should generally be set to string `"AXIC"`.
+- `$(AXIC)\snps,wr_osr_lmt` (default = 4): Controls the value of `GMAC_DMA_SysBus_Mode.WR_OSR_LMT`, i.e. AXI maximum write outstanding request limit.
+- `$(AXIC)\snps,rd_osr_lmt` (default = 8): Controls the value of `GMAC_DMA_SysBus_Mode.RD_OSR_LMT`, i.e. AXI maximum read outstanding request limit.
+- `$(AXIC)\snps,blen` (default = `{ 16, 8, 4 }`): Controls the values of `GMAC_DMA_SysBus_Mode.BLENx` (x = 4, 8, 16, 32, 64, 128, 256), i.e. AXI burst length. Should be a list of 7 integers, e.g. `Package () { 0, 0, 0, 0, 16, 8, 4 }`.
+
+## Areas for improvement:
+
+- Run against network test suites and fix any issues.
+- Memory optimizations? Current implementation uses system-managed buffers.
+  System-managed buffer size is tied to MTU. When jumbo frames are enabled,
+  this is wasteful since most packets are still 1522 bytes or less. If we
+  used driver-managed buffers and updated the Rx queue to handle multi-buffer
+  packets, we could use 1536-byte or 2048-byte buffers for the Rx queue, saving
+  about 2MB per device when JumboPacket = 9014.
+- Configure speed, duplex via Ndi\params?
+- Power control, wake-on-LAN, ARP offload?
+- Multi-queue, RSS support?
+- Make it more generic (test with other EQoS-based SoCs)?

--- a/drivers/net/dwc_eqos/descriptors.h
+++ b/drivers/net/dwc_eqos/descriptors.h
@@ -21,6 +21,14 @@ enum TxChecksumInsertion : UINT16
     TxChecksumInsertionEnabledIncludingPseudo = 3,
 };
 
+enum TxVlanTagControl : UINT16
+{
+    TxVlanTagControlNone = 0,
+    TxVlanTagControlRemove = 1,
+    TxVlanTagControlInsert = 2,
+    TxVlanTagControlReplace = 3,
+};
+
 struct TxDescriptorRead
 {
     // TDES0, TDES1
@@ -31,7 +39,7 @@ struct TxDescriptorRead
     // TDES2
 
     UINT16 Buf1Length : 14; // B1L
-    UINT16 VlanTagControl : 2; // VTIR
+    TxVlanTagControl VlanTagControl : 2; // VTIR
 
     UINT16 Buf2Length : 14; // B2L
     UINT16 TransmitTimestampEnable : 1; // TTSE
@@ -68,7 +76,7 @@ struct TxDescriptorReadTso
     // TDES2
 
     UINT16 Buf1Length : 14; // B1L (10-bit header length if FD = 1)
-    UINT16 VlanTagControl : 2; // VTIR
+    TxVlanTagControl VlanTagControl : 2; // VTIR
 
     UINT16 Buf2Length : 14; // B2L
     UINT16 TsoMemoryWriteDisable : 1; // TMWD
@@ -77,7 +85,7 @@ struct TxDescriptorReadTso
     // TDES3
 
     UINT32 TcpPayloadLength : 18; // TPL
-    UINT32 TcpSegmentationEnable : 1; // TSE = 0
+    UINT32 TcpSegmentationEnable : 1; // TSE = 1
     UINT32 TcpHeaderLength : 4; // TCP/UDP header length (must be 2 for UDP)
     UINT32 SourceAddressInsertionControl : 3; // SAIC
     UINT32 Reserved26 : 2; // CPC, ignored when TSE = 1
@@ -159,7 +167,7 @@ struct TxDescriptorContext
 
     UINT8 VlanTagValid : 1; // VLTV
     UINT8 InnerVlanTagValid : 1; // IVLTV
-    UINT8 InnverVlanTagControl : 2; // IVTIR
+    UINT8 InnerVlanTagControl : 2; // IVTIR
     UINT8 Reserved20 : 3;
     UINT8 DescriptorError : 1; // DE
 

--- a/drivers/net/dwc_eqos/device.h
+++ b/drivers/net/dwc_eqos/device.h
@@ -8,8 +8,6 @@ struct DeviceContext; // TODO: if we do multi-queue, make a DeviceQueueContext s
 // Information about the device provided to the queues.
 struct DeviceConfig
 {
-    bool txCoeSel;      // MAC_HW_Feature0\TXCOESEL (hardware support for tx checksum offload).
-    bool rxCoeSel;      // MAC_HW_Feature0\RXCOESEL (hardware support for rx checksum offload).
     bool pblX8;         // _DSD\snps,pblx8 (default = 1).
     UINT8 pbl;          // _DSD\snps,pbl (default = 8; effect depends on pblX8).
     UINT8 txPbl;        // _DSD\snps,txpbl (default = pbl; effect depends on pblX8).
@@ -21,7 +19,7 @@ struct DeviceConfig
     UINT8 blen : 7;     // AXIC\snps,blen bitmask of 7 booleans 4..256 (default = 4, 8, 16).
     bool txFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
     bool rxFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
-    UINT16 jumboFrame;  // Adapter configuration (Ndi\params\*JumboFrame). 1514..4088
+    UINT16 jumboFrame;  // Adapter configuration (Ndi\params\*JumboFrame). 1514..9014.
 
     UINT16 RxBufferSize() const
     {

--- a/drivers/net/dwc_eqos/driver.cpp
+++ b/drivers/net/dwc_eqos/driver.cpp
@@ -2,15 +2,6 @@
 #include "device.h"
 #include "trace.h"
 
-/*
-Possible areas for improvement:
-- Tx segmentation offload.
-- Run against network test suites and fix any issues.
-- Power control, wake-on-LAN, ARP offload.
-- Configure speed, duplex in Ndi\params.
-- Multi-queue support?
-*/
-
 TRACELOGGING_DEFINE_PROVIDER(
     TraceProvider,
     "dwc_eqos",

--- a/drivers/net/dwc_eqos/dwc_eqos.inf
+++ b/drivers/net/dwc_eqos/dwc_eqos.inf
@@ -96,7 +96,7 @@ HKR, Ndi\params\*FlowControl,                    type,           0,  "enum"
 HKR, Ndi\params\*FlowControl\enum,               "0",            0,  %Disabled%
 HKR, Ndi\params\*FlowControl\enum,               "1",            0,  %TxEnabled%
 HKR, Ndi\params\*FlowControl\enum,               "2",            0,  %RxEnabled%
-HKR, Ndi\params\*FlowControl\enum,               "3",            0,  %TxRxEnabled%
+HKR, Ndi\params\*FlowControl\enum,               "3",            0,  %RxTxEnabled%
 
 HKR, Ndi\Params\*PriorityVLANTag,                ParamDesc,      0,  %PriorityVlanTag%
 HKR, Ndi\Params\*PriorityVLANTag,                Default,        0,  "3"
@@ -106,21 +106,69 @@ HKR, Ndi\Params\*PriorityVLANTag\enum,           "1",            0,  %PriorityEn
 HKR, Ndi\Params\*PriorityVLANTag\enum,           "2",            0,  %VlanEnabled%
 HKR, Ndi\Params\*PriorityVLANTag\enum,           "3",            0,  %PriorityVlanEnabled%
 
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4,      ParamDesc,      0,  %TCPUDPChecksumOffloadIPv4%
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4,      default,        0,  "3"
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4,      type,           0,  "enum"
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4\enum, "0",            0,  %Disabled%
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4\enum, "1",            0,  %TxEnabled%
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4\enum, "2",            0,  %RxEnabled%
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv4\enum, "3",            0,  %TxRxEnabled%
+HKR, Ndi\params\*IPChecksumOffloadIPv4,          ParamDesc,      0,  %IPChecksumOffloadIPv4%
+HKR, Ndi\params\*IPChecksumOffloadIPv4,          default,        0,  "3"
+HKR, Ndi\params\*IPChecksumOffloadIPv4,          type,           0,  "enum"
+HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "0",            0,  %Disabled%
+HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "1",            0,  %TxEnabled%
+HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "2",            0,  %RxEnabled%
+HKR, Ndi\params\*IPChecksumOffloadIPv4\enum,     "3",            0,  %RxTxEnabled%
 
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6,      ParamDesc,      0,  %TCPUDPChecksumOffloadIPv6%
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6,      default,        0,  "3"
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6,      type,           0,  "enum"
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6\enum, "0",            0,  %Disabled%
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6\enum, "1",            0,  %TxEnabled%
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6\enum, "2",            0,  %RxEnabled%
-HKR, Ndi\params\*TCPUDPChecksumOffloadIPv6\enum, "3",            0,  %TxRxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4,         ParamDesc,      0,  %TCPChecksumOffloadIPv4%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4,         default,        0,  "3"
+HKR, Ndi\params\*TCPChecksumOffloadIPv4,         type,           0,  "enum"
+HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "0",            0,  %Disabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "1",            0,  %TxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "2",            0,  %RxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv4\enum,    "3",            0,  %RxTxEnabled%
+
+HKR, Ndi\params\*UDPChecksumOffloadIPv4,         ParamDesc,      0,  %UDPChecksumOffloadIPv4%
+HKR, Ndi\params\*UDPChecksumOffloadIPv4,         default,        0,  "3"
+HKR, Ndi\params\*UDPChecksumOffloadIPv4,         type,           0,  "enum"
+HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "0",            0,  %Disabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "1",            0,  %TxEnabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "2",            0,  %RxEnabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv4\enum,    "3",            0,  %RxTxEnabled%
+
+HKR, Ndi\params\*TCPChecksumOffloadIPv6,         ParamDesc,      0,  %TCPChecksumOffloadIPv6%
+HKR, Ndi\params\*TCPChecksumOffloadIPv6,         default,        0,  "3"
+HKR, Ndi\params\*TCPChecksumOffloadIPv6,         type,           0,  "enum"
+HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "0",            0,  %Disabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "1",            0,  %TxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "2",            0,  %RxEnabled%
+HKR, Ndi\params\*TCPChecksumOffloadIPv6\enum,    "3",            0,  %RxTxEnabled%
+
+HKR, Ndi\params\*UDPChecksumOffloadIPv6,         ParamDesc,      0,  %UDPChecksumOffloadIPv6%
+HKR, Ndi\params\*UDPChecksumOffloadIPv6,         default,        0,  "3"
+HKR, Ndi\params\*UDPChecksumOffloadIPv6,         type,           0,  "enum"
+HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "0",            0,  %Disabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "1",            0,  %TxEnabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "2",            0,  %RxEnabled%
+HKR, Ndi\params\*UDPChecksumOffloadIPv6\enum,    "3",            0,  %RxTxEnabled%
+
+HKR, Ndi\Params\*LsoV2IPv4,                      ParamDesc,      0,  %LsoV2IPv4%
+HKR, Ndi\Params\*LsoV2IPv4,                      Type,           0,  "enum"
+HKR, Ndi\Params\*LsoV2IPv4,                      Default,        0,  "1"
+HKR, Ndi\Params\*LsoV2IPv4\enum,                 "0",            0,  %Disabled%
+HKR, Ndi\Params\*LsoV2IPv4\enum,                 "1",            0,  %Enabled%
+
+HKR, Ndi\Params\*LsoV2IPv6,                      ParamDesc,      0,  %LsoV2IPv6%
+HKR, Ndi\Params\*LsoV2IPv6,                      Type,           0,  "enum"
+HKR, Ndi\Params\*LsoV2IPv6,                      Default,        0,  "1"
+HKR, Ndi\Params\*LsoV2IPv6\enum,                 "0",            0,  %Disabled%
+HKR, Ndi\Params\*LsoV2IPv6\enum,                 "1",            0,  %Enabled%
+
+HKR, Ndi\Params\*UsoIPv4,                        ParamDesc,      0,  %UsoIPv4%
+HKR, Ndi\Params\*UsoIPv4,                        Type,           0,  "enum"
+HKR, Ndi\Params\*UsoIPv4,                        Default,        0,  "1"
+HKR, Ndi\Params\*UsoIPv4\enum,                   "0",            0,  %Disabled%
+HKR, Ndi\Params\*UsoIPv4\enum,                   "1",            0,  %Enabled%
+
+HKR, Ndi\Params\*UsoIPv6,                        ParamDesc,      0,  %UsoIPv6%
+HKR, Ndi\Params\*UsoIPv6,                        Type,           0,  "enum"
+HKR, Ndi\Params\*UsoIPv6,                        Default,        0,  "1"
+HKR, Ndi\Params\*UsoIPv6\enum,                   "0",            0,  %Disabled%
+HKR, Ndi\Params\*UsoIPv6\enum,                   "1",            0,  %Enabled%
 
 [DWCEQOS_Device.NT.Services]
 AddService = %ServiceName%, 2, DWCEQOS_AddService, DWCEQOS_AddService_EventLog
@@ -158,12 +206,20 @@ NetworkAddress      = "Network Address"
 JumboPacket         = "Jumbo Packet"
 FlowControl         = "Flow Control"
 PriorityVlanTag     = "Packet Priority & VLAN"
-TCPUDPChecksumOffloadIPv4 = "TCP/UDP Checksum Offload (IPv4)"
-TCPUDPChecksumOffloadIPv6 = "TCP/UDP Checksum Offload (IPv6)"
+IPChecksumOffloadIPv4  = "IPv4 Checksum Offload"
+TCPChecksumOffloadIPv4 = "TCP Checksum Offload (IPv4)"
+TCPChecksumOffloadIPv6 = "TCP Checksum Offload (IPv6)"
+UDPChecksumOffloadIPv4 = "UDP Checksum Offload (IPv4)"
+UDPChecksumOffloadIPv6 = "UDP Checksum Offload (IPv6)"
+LsoV2IPv4           = "Large Send Offload V2 (IPv4)"
+LsoV2IPv6           = "Large Send Offload V2 (IPv6)"
+UsoIPv4             = "UDP Segmentation Offload (IPv4)"
+UsoIPv6             = "UDP Segmentation Offload (IPV6)"
 Disabled            = "Disabled"
+Enabled             = "Enabled"
 TxEnabled           = "Tx Enabled"
 RxEnabled           = "Rx Enabled"
-TxRxEnabled         = "Tx and Rx Enabled"
+RxTxEnabled         = "Rx & Tx Enabled"
 PriorityEnabled     = "Packet Priority Enabled"
 VlanEnabled         = "VLAN Enabled"
 PriorityVlanEnabled = "Packet Priority & VLAN Enabled"

--- a/drivers/net/dwc_eqos/dwc_eqos.vcxproj
+++ b/drivers/net/dwc_eqos/dwc_eqos.vcxproj
@@ -151,6 +151,10 @@
   <ItemGroup>
     <ResourceCompile Include="dwc_eqos.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="AutoLogger.reg" />
+    <None Include="README.md" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/drivers/net/dwc_eqos/dwc_eqos.vcxproj.filters
+++ b/drivers/net/dwc_eqos/dwc_eqos.vcxproj.filters
@@ -84,4 +84,12 @@
       <Filter>Driver Files</Filter>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="AutoLogger.reg">
+      <Filter>Driver Files</Filter>
+    </None>
+    <None Include="README.md">
+      <Filter>Driver Files</Filter>
+    </None>
+  </ItemGroup>
 </Project>

--- a/drivers/net/dwc_eqos/precomp.h
+++ b/drivers/net/dwc_eqos/precomp.h
@@ -8,6 +8,7 @@
 #pragma warning(pop)
 
 #include <netadaptercx.h>
+#include <net/gso.h>
 #include <net/ieee8021q.h>
 #include <net/logicaladdress.h>
 #include <net/virtualaddress.h>

--- a/drivers/net/dwc_eqos/queue_common.h
+++ b/drivers/net/dwc_eqos/queue_common.h
@@ -3,9 +3,10 @@ Definitions shared between TxQueue and RxQueue.
 */
 #pragma once
 
-UINT32 constexpr QueueDescriptorSize = 64; // 64 == sizeof(TxDescriptor) == sizeof(RxDescriptor)
-UINT32 constexpr QueueDescriptorMinCount = PAGE_SIZE / QueueDescriptorSize; // Page granularity for allocation, might as well use the whole page.
-UINT32 constexpr QueueDescriptorMaxCount = 0x400; // Hardware limitation.
+UINT16 constexpr QueueDescriptorSize = 64; // 64 == sizeof(TxDescriptor) == sizeof(RxDescriptor)
+UINT16 constexpr QueueDescriptorMinCount = PAGE_SIZE / QueueDescriptorSize; // Page granularity for allocation, might as well use the whole page.
+UINT16 constexpr QueueDescriptorMaxCount = 0x400; // Hardware limitation.
+UINT16 constexpr QueueDescriptorLengthMax = 0x3FFF; // 14 bits.
 
 // Alignment is primarily to make sure the allocation does not cross a 4GB boundary.
 // It also simplifies the QueueDescriptorAddressToIndex implementation.

--- a/drivers/net/dwc_eqos/trace.h
+++ b/drivers/net/dwc_eqos/trace.h
@@ -8,9 +8,11 @@ Collect traces using something like:
     tracefmt FileName.etl
 
 Send traces to KD by running "!wmitrace.dynamicprint 1" in WinDbg and starting a trace
-session with -kd enabled, either via trace tool or via autologger:
+session with -kd enabled, either via trace tool,
 
     tracelog -start SessionName -guid *dwc_eqos -level 4 -kd
+
+or by setting up a boot-start session using the AutoLogger.reg file in this project.
 */
 #pragma once
 

--- a/drivers/net/dwc_eqos/txqueue.h
+++ b/drivers/net/dwc_eqos/txqueue.h
@@ -2,11 +2,18 @@
 Transmit queue behavior. Similar to the receive queue.
 */
 #pragma once
+#include "queue_common.h"
 
 struct DeviceContext;
 struct DeviceConfig;
 struct ChannelRegisters;
 struct MtlQueueRegisters;
+
+// 3 = 1 hole in the ring + 1 context descriptor + 1 TSE descriptor.
+UINT32 constexpr TxMaximumNumberOfFragments = QueueDescriptorMinCount - 3;
+
+UINT16 constexpr TxLayer4HeaderOffsetLimit = 0x3FF; // 10 bits.
+UINT32 constexpr TxMaximumOffloadSize = 0x3FFFF; // 18 bits.
 
 // Called by device.cpp AdapterCreateTxQueue.
 _IRQL_requires_same_


### PR DESCRIPTION
- Add a README.md.
- Add a REG file for enabling a diagnostic ETW autologger.
- Implement TCP segmentation offload (LSOv2).
- Implement UDP fragmentation offload (USO).
- Instead of making a half-baked effort to adapt to disabled hardware features (i.e. lack of Checksum or Segment offload support), check for the feature and don't load if it's missing. At present, I have nothing to test this on and it just makes the code messy. We can add adaptability back in the future if anybody actually wants it and has hardware to test it.
- Fix problems with error logging in Tx path (error bit is only valid for LastDescriptor).
- Fix problems with VLAN tag insertion.
- Fix problems with checksum offload configuration. NetAdapterCx only recognizes the "granular" options.