### PR TITLE
dwc_eqos - fix transmitted vlan tags

### DIFF
--- a/drivers/net/dwc_eqos/device.h
+++ b/drivers/net/dwc_eqos/device.h
@@ -20,6 +20,7 @@ struct DeviceConfig
     bool txFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
     bool rxFlowControl; // Adapter configuration (Ndi\params\*FlowControl).
     UINT16 jumboFrame;  // Adapter configuration (Ndi\params\*JumboFrame). 1514..9014.
+    UINT16 vlanId;      // Adapter configuration (Ndi\params\*VlanID). 0..4095.
 
     UINT16 RxBufferSize() const
     {

--- a/drivers/net/dwc_eqos/dwc_eqos.inf
+++ b/drivers/net/dwc_eqos/dwc_eqos.inf
@@ -84,6 +84,12 @@ HKR, Ndi\params\NetworkAddress,                  LimitText,      0, "12"
 HKR, Ndi\params\NetworkAddress,                  UpperCase,      0, "1"
 HKR, Ndi\params\NetworkAddress,                  Optional,       0, "1"
 
+HKR, Ndi\params\VlanID,                          ParamDesc,      0, %VlanID%
+HKR, Ndi\params\VlanID,                          type,           0, "int"
+HKR, Ndi\params\VlanID,                          default,        0, "0"
+HKR, Ndi\params\VlanID,                          min,            0, "0"
+HKR, Ndi\params\VlanID,                          max,            0, "4094"
+
 HKR, Ndi\params\*JumboPacket,                    ParamDesc,      0, %JumboPacket%
 HKR, Ndi\params\*JumboPacket,                    type,           0, "int"
 HKR, Ndi\params\*JumboPacket,                    default,        0, "1514"
@@ -203,6 +209,7 @@ RKCP                = "Rockchip"
 DWCEQOS.DeviceDesc  = "Synopsys DesignWare Ethernet Quality of Service (GMAC)"
 DWCEQOS.ServiceDesc = "DesignWare Ethernet"
 NetworkAddress      = "Network Address"
+VlanID              = "VLAN ID"
 JumboPacket         = "Jumbo Packet"
 FlowControl         = "Flow Control"
 PriorityVlanTag     = "Packet Priority & VLAN"

--- a/drivers/net/dwc_eqos/registers.h
+++ b/drivers/net/dwc_eqos/registers.h
@@ -676,6 +676,25 @@ union MacVlanTagCtrl_t
     };
 };
 
+union MacVlanIncl_t
+{
+    UINT32 Value32;
+    struct
+    {
+        UINT16 VlanTagTx; // VLT
+
+        UINT8 VlanControl : 2; // VLC
+        UINT8 VlanControlPriority : 1; // VLP
+        UINT8 VlanS : 1; // CSVL
+        UINT8 VlanInput : 1; // VLTI
+        UINT8 VLanChannelInsertion : 1;
+        UINT8 Reserved22 : 2;
+        UINT8 Addr : 6; // ADDR
+        UINT8 ReadWriteControl : 1; // RDWR
+        UINT8 Busy : 1; // BUSY
+    };
+};
+
 union MacInterruptStatus_t
 {
     UINT32 Value32;
@@ -995,7 +1014,7 @@ struct MacRegisters
     // The VLAN Tag Inclusion or Replacement register contains the VLAN tag for
     // insertion or replacement in the Transmit packets. It also contains the VLAN tag
     // insertion controls.
-    ULONG Mac_Vlan_Incl;
+    MacVlanIncl_t Mac_Vlan_Incl;
 
     // MAC_Inner_VLAN_Incl @ 0x0064 = 0x0:
     // The Inner VLAN Tag Inclusion or Replacement register contains the inner VLAN


### PR DESCRIPTION
All transmitted VLAN tags were 0. We weren't setting the VlanInput flag, so when inserting VLAN tags, the adapter was using a global value (0) instead of the value from the descriptor ring. Fix.

- Set the VlanInput flag so that inserted VLAN tags are taken from context descriptor.
- Add a VLAN ID configuration setting. This is a semi-standard tag, and I couldn't find great details on how it is supposed to work. At present, it just controls the default VLAN tag to use when transmitting. I think some adapters also use it to filter received packets, but I don't think that's a good idea for this driver since NetAdapterCx doesn't support OID_GEN_VLAN_ID.
- Update Tx path to handle a default VLAN tag. Ended up cleaning things up a bit so the result is shorter.