### PR TITLE
Usbehci - INF-only (override driver) for noncoherent systems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,9 @@ jobs:
     - name: Bundle symbols
       run: |
         Get-ChildItem -Path $env:DRIVER_OUTPUT_DIR -Directory | ForEach-Object {
-            Copy-Item -Path "$env:DRIVER_OUTPUT_DIR\$($_.Name).pdb" -Destination $_.FullName
+            if (Test-Path -Path "$env:DRIVER_OUTPUT_DIR\$($_.Name).pdb") {
+                Copy-Item -Path "$env:DRIVER_OUTPUT_DIR\$($_.Name).pdb" -Destination $_.FullName
+            }
         }
       
     - name: Get version tag

--- a/build/RockchipDrivers.sln
+++ b/build/RockchipDrivers.sln
@@ -29,6 +29,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "csaudio-Utilities", "..\dri
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dwc_eqos", "..\drivers\net\dwc_eqos\dwc_eqos.vcxproj", "{CAD465B6-97D7-402D-85F8-50DE140A6D9D}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "usbehci_noncoherent", "..\drivers\usb\usbehci_noncoherent\usbehci_noncoherent.vcxproj", "{BB0C35DD-3009-4CA5-86C8-B255D378A84B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -99,6 +101,12 @@ Global
 		{CAD465B6-97D7-402D-85F8-50DE140A6D9D}.Release|ARM64.ActiveCfg = Release|ARM64
 		{CAD465B6-97D7-402D-85F8-50DE140A6D9D}.Release|ARM64.Build.0 = Release|ARM64
 		{CAD465B6-97D7-402D-85F8-50DE140A6D9D}.Release|ARM64.Deploy.0 = Release|ARM64
+		{BB0C35DD-3009-4CA5-86C8-B255D378A84B}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{BB0C35DD-3009-4CA5-86C8-B255D378A84B}.Debug|ARM64.Build.0 = Debug|ARM64
+		{BB0C35DD-3009-4CA5-86C8-B255D378A84B}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{BB0C35DD-3009-4CA5-86C8-B255D378A84B}.Release|ARM64.ActiveCfg = Release|ARM64
+		{BB0C35DD-3009-4CA5-86C8-B255D378A84B}.Release|ARM64.Build.0 = Release|ARM64
+		{BB0C35DD-3009-4CA5-86C8-B255D378A84B}.Release|ARM64.Deploy.0 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/drivers/usb/usbehci_noncoherent/usbehci_noncoherent.inf
+++ b/drivers/usb/usbehci_noncoherent/usbehci_noncoherent.inf
@@ -1,0 +1,33 @@
+; Extension INF that enables the "NoInterlockedOpOnCommonBuffers" option for
+; usbehci. This option was introduced in Windows 11 2024.
+
+[Version]
+Signature   = "$Windows NT$"
+Class       = Extension
+ClassGuid   = {e2f84ce7-8efa-411c-aa69-97454ca4cb57}
+Provider    = %Provider%
+ExtensionId = {53e4ec2a-0b83-410f-b29c-1922fd636ca5}
+DriverVer   = ; provided by stampinf
+CatalogFile = usbehci_noncoherent.cat
+PnpLockdown = 1
+
+[Manufacturer]
+%Provider% = DeviceExtension,NTarm64
+
+[DeviceExtension.NTarm64]
+%ExtensionDesc% = DeviceExtension_Install, ACPI\PNP0D20
+
+[DeviceExtension_Install]
+; No changes
+
+[DeviceExtension_Install.HW]
+AddReg = NoInterlockedOp_AddReg
+
+[NoInterlockedOp_AddReg]
+HKR,, NoInterlockedOpOnCommonBuffers, 0x10001, 0x00000001
+HKR,, FriendlyName,, %FriendlyName%
+
+[Strings]
+Provider      = "Open Source"
+ExtensionDesc = "usbehci with NoInterlockedOpOnCommonBuffers"
+FriendlyName  = "Standard EHCI-compliant Host Controller (NCC)"

--- a/drivers/usb/usbehci_noncoherent/usbehci_noncoherent.inf
+++ b/drivers/usb/usbehci_noncoherent/usbehci_noncoherent.inf
@@ -1,33 +1,56 @@
-; Extension INF that enables the "NoInterlockedOpOnCommonBuffers" option for
+; Override INF that enables the "NoInterlockedOpOnCommonBuffers" option for
 ; usbehci. This option was introduced in Windows 11 2024.
 
 [Version]
 Signature   = "$Windows NT$"
-Class       = Extension
-ClassGuid   = {e2f84ce7-8efa-411c-aa69-97454ca4cb57}
+Class       = USB
+ClassGuid   = {36fc9e60-c465-11cf-8056-444553540000}
 Provider    = %Provider%
-ExtensionId = {53e4ec2a-0b83-410f-b29c-1922fd636ca5}
 DriverVer   = ; provided by stampinf
 CatalogFile = usbehci_noncoherent.cat
 PnpLockdown = 1
 
+[ControlFlags]
+ExcludeFromSelect = *
+
 [Manufacturer]
-%Provider% = DeviceExtension,NTarm64
+%Provider% = Generic.Section,NTarm64.10.0...26038
 
-[DeviceExtension.NTarm64]
-%ExtensionDesc% = DeviceExtension_Install, ACPI\PNP0D20
+[Generic.Section.NTarm64.10.0...26038]
+%EhciPci.DeviceDesc% = EHCI.Dev,     PCI\CC_0C0320
+%EhciSoc.DeviceDesc% = EHCI_SOC.Dev, *PNP0D20
+%EhciSoc.DeviceDesc% = EHCI_SOC.Dev, *PNP0FFC
+%EhciSoc.DeviceDesc% = EHCI_SOC.Dev, ACPI\PNP0D20
+%EhciSoc.DeviceDesc% = EHCI_SOC.Dev, ACPI\RKCP0D20
 
-[DeviceExtension_Install]
-; No changes
+[EHCI.Dev.NT]
+FeatureScore = 1
+Include      = usbport.inf
+Needs        = EHCI.Dev.NT
 
-[DeviceExtension_Install.HW]
+[EHCI.Dev.NT.Services]
+Include = usbport.inf
+Needs   = EHCI.Dev.NT.Services
+
+[EHCI.Dev.NT.HW]
+AddReg  = NoInterlockedOp_AddReg
+
+[EHCI_SOC.Dev.NT]
+FeatureScore = 1
+Include      = usbport.inf
+Needs        = EHCI_SOC.Dev.NT
+
+[EHCI_SOC.Dev.NT.Services]
+Include = usbport.inf
+Needs   = EHCI.Dev.NT.Services
+
+[EHCI_SOC.Dev.NT.HW]
 AddReg = NoInterlockedOp_AddReg
 
 [NoInterlockedOp_AddReg]
 HKR,, NoInterlockedOpOnCommonBuffers, 0x10001, 0x00000001
-HKR,, FriendlyName,, %FriendlyName%
 
 [Strings]
-Provider      = "Open Source"
-ExtensionDesc = "usbehci with NoInterlockedOpOnCommonBuffers"
-FriendlyName  = "Standard EHCI-compliant Host Controller (NCC)"
+Provider           = "Open Source"
+EhciPci.DeviceDesc = "Standard Enhanced PCI to USB Host Controller (NCC)"
+EhciSoc.DeviceDesc = "Standard EHCI-compliant Host Controller (NCC)"

--- a/drivers/usb/usbehci_noncoherent/usbehci_noncoherent.vcxproj
+++ b/drivers/usb/usbehci_noncoherent/usbehci_noncoherent.vcxproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="usbehci_noncoherent.inf" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{BB0C35DD-3009-4CA5-86C8-B255D378A84B}</ProjectGuid>
+    <TemplateGuid>{4605da2c-74a5-4865-98e1-152ef136825f}</TemplateGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration>Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <RootNamespace>usbehci_noncoherent</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Utility</ConfigurationType>
+    <DriverType>Package</DriverType>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Utility</ConfigurationType>
+    <DriverType>Package</DriverType>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Import Project="..\..\..\build\common.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Import Project="..\..\..\build\common.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <HardwareIdString />
+    <CommandLine />
+    <DeployFiles />
+    <EnableVerifier>False</EnableVerifier>
+    <AllDrivers>False</AllDrivers>
+    <VerifyProjectOutput>True</VerifyProjectOutput>
+    <VerifyDrivers />
+    <VerifyFlags>133563</VerifyFlags>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <HardwareIdString />
+    <CommandLine />
+    <DeployFiles />
+    <EnableVerifier>False</EnableVerifier>
+    <AllDrivers>False</AllDrivers>
+    <VerifyProjectOutput>True</VerifyProjectOutput>
+    <VerifyDrivers />
+    <VerifyFlags>133563</VerifyFlags>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/drivers/usb/usbehci_noncoherent/usbehci_noncoherent.vcxproj.filters
+++ b/drivers/usb/usbehci_noncoherent/usbehci_noncoherent.vcxproj.filters
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Driver Files">
+      <UniqueIdentifier>{8E41214B-6785-4CFE-B992-037D68949A14}</UniqueIdentifier>
+      <Extensions>inf;inv;inx;mof;mc;</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="usbehci_noncoherent.inf">
+      <Filter>Driver Files</Filter>
+    </Inf>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Add `usbehci_noncoherent` inf-only driver to support USBEHCI on non-cache-coherent devices.

- Applies to `ACPI\RKCP0D20` as well as standard USBEHCI devices (PNP0D20, etc.).
- Applies to Windows versions 26038 and later.
- When applied, it loads the in-box usbehci.sys driver and adds the `NoInterlockedOpOnCommonBuffers=1` flag.