### PR TITLE
dwcmshc/dwcsdhc: Restricted install on 10.0.16299 or higher OS

### DIFF
--- a/drivers/sd/dwcmshc/dwcmshc.inx
+++ b/drivers/sd/dwcmshc/dwcmshc.inx
@@ -27,7 +27,7 @@ PnpLockdown = 1
 dwcmshc.sys = 1
 
 [Manufacturer]
-%RKCP% = RKCP,NT$ARCH$
+%RKCP% = RKCP,NT$ARCH$.10.0...16299
 
 [ControlFlags]
 ExcludeFromSelect = *
@@ -36,7 +36,7 @@ ExcludeFromSelect = *
 ; Rockchip models
 ;
 
-[RKCP.NT$ARCH$]
+[RKCP.NT$ARCH$.10.0...16299]
 %DWCMSHC.DeviceDesc% = ROCKCHIP, ACPI\RKCPFE2C
 
 ;

--- a/drivers/sd/dwcsdhc/dwcsdhc.inx
+++ b/drivers/sd/dwcsdhc/dwcsdhc.inx
@@ -28,7 +28,7 @@ PnpLockdown=1
 dwcsdhc.sys = 1
 
 [Manufacturer]
-%RKCP%=RKCP,NT$ARCH$
+%RKCP%=RKCP,NT$ARCH$.10.0...16299
 
 [ControlFlags]
 ExcludeFromSelect=*
@@ -37,7 +37,7 @@ ExcludeFromSelect=*
 ; Rockchip models
 ;
 
-[RKCP.NT$ARCH$]
+[RKCP.NT$ARCH$.10.0...16299]
 %ACPI\RKCP0D40.DeviceDesc%=DWCSDHC, ACPI\RKCP0D40
 
 ;


### PR DESCRIPTION
The syntax 'DIRID 13 (CopyFiles)' was introduced in OS version 10.0.16299, but DDInstall sections utilizing the syntax will install on earlier OS versions. Those DDInstall sections should be restricted to only install on 10.0.16299 or higher using a TargetOSVersion decoration.