### PR TITLE
Fix build warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         Write-Output "version=$($version)" >> $env:GITHUB_OUTPUT
         
     - name: Upload testsigned driver package artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: RkDrvPkg_${{matrix.PLATFORM}}_${{matrix.CONFIGURATION}}_${{steps.get_version_tag.outputs.version}}_testsigned
         path: ${{env.DRIVER_OUTPUT_DIR}}/*/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,9 @@ jobs:
       uses: actions/checkout@v3
       
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
+      with:
+        msbuild-architecture: x64
   
     - name: Build solution
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/drivers/audio/codecs/es8323/es8323.c
+++ b/drivers/audio/codecs/es8323/es8323.c
@@ -1,6 +1,5 @@
 #define DESCRIPTOR_DEF
 #include "driver.h"
-#include "stdint.h"
 
 #define bool int
 #define MS_IN_US 1000
@@ -117,16 +116,16 @@ void udelay(ULONG usec) {
 
 /* ES8288 has 8-bit register addresses, and 8-bit register data */
 struct es8323_init_reg {
-	uint8_t reg;
-	uint8_t val;
+	UINT8 reg;
+	UINT8 val;
 };
 
 NTSTATUS es8323_reg_read(
 	_In_ PES8323_CONTEXT pDevice,
-	uint8_t reg,
-	uint8_t* data
+	UINT8 reg,
+	UINT8* data
 ) {
-	uint8_t raw_data = 0;
+	UINT8 raw_data = 0;
 	NTSTATUS status = SpbXferDataSynchronously(&pDevice->I2CContext, &reg, sizeof(reg), &raw_data, sizeof(raw_data));
 	*data = raw_data;
 	return status;
@@ -134,10 +133,10 @@ NTSTATUS es8323_reg_read(
 
 NTSTATUS es8323_reg_write(
 	_In_ PES8323_CONTEXT pDevice,
-	uint8_t reg,
-	uint8_t data
+	UINT8 reg,
+	UINT8 data
 ) {
-	uint8_t buf[2];
+	UINT8 buf[2];
 	buf[0] = reg;
 	buf[1] = data;
 	return SpbWriteDataSynchronously(&pDevice->I2CContext, buf, sizeof(buf));
@@ -145,11 +144,11 @@ NTSTATUS es8323_reg_write(
 
 NTSTATUS es8323_reg_update(
 	_In_ PES8323_CONTEXT pDevice,
-	uint8_t reg,
-	uint8_t mask,
-	uint8_t val
+	UINT8 reg,
+	UINT8 mask,
+	UINT8 val
 ) {
-	uint8_t tmp = 0, orig = 0;
+	UINT8 tmp = 0, orig = 0;
 
 	NTSTATUS status = es8323_reg_read(pDevice, reg, &orig);
 	if (!NT_SUCCESS(status)) {
@@ -167,12 +166,12 @@ NTSTATUS es8323_reg_update(
 
 /*static void debug_dump_regs(PES8323_CONTEXT pDevice)
 {
-	uint8_t i, reg_byte;
+	UINT8 i, reg_byte;
 	// Show all codec regs
 	for (i = 0; i <= ES8323_DACCONTROL30; i += 16) {
 		uint32_t regs[16];
 		for (int j = 0; j < 16; j++) {
-			es8323_reg_read(pDevice, (uint8_t)(i + j), &reg_byte);
+			es8323_reg_read(pDevice, (UINT8)(i + j), &reg_byte);
 			regs[j] = reg_byte;
 		}
 		DbgPrint("%02x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x \n", i, regs[0], regs[1], regs[2], regs[3], regs[4], regs[5], regs[6], regs[7],

--- a/drivers/audio/csaudiork3x/Source/Inc/Inc.vcxproj
+++ b/drivers/audio/csaudiork3x/Source/Inc/Inc.vcxproj
@@ -64,16 +64,16 @@
     </DriverSign>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <Inf Exclude="@(Inf)" Include="*.inf" />
     <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
   </ItemGroup>
   <ItemGroup>
-    <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
-    <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
-    <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
+    <ClInclude Include="basetopo.h" />
+    <ClInclude Include="common.h" />
+    <ClInclude Include="definitions.h" />
+    <ClInclude Include="endpoints.h" />
+    <ClInclude Include="kshelper.h" />
+    <ClInclude Include="mintopo.h" />
+    <ClInclude Include="NewDelete.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/drivers/audio/csaudiork3x/Source/Main/Main.vcxproj
+++ b/drivers/audio/csaudiork3x/Source/Main/Main.vcxproj
@@ -115,13 +115,8 @@
     <ResourceCompile Include="csaudiork3x.rc" />
   </ItemGroup>
   <ItemGroup>
-    <Inf Exclude="@(Inx)" Include="*.inx" />
+    <Inf Include="csaudiork3x.inx" />
     <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
-    <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
-    <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="common.h" />

--- a/drivers/audio/csaudiork3x/Source/Main/csaudiork3x.inx
+++ b/drivers/audio/csaudiork3x/Source/Main/csaudiork3x.inx
@@ -28,12 +28,12 @@ PETrust=true
 %CAAUDIORK3X_SA.DeviceDesc%=CAAUDIORK3X_SA, CSAUDIO\RK&CLTR
 
 [DestinationDirs]
-CAAUDIORK3X_SA.CopyList=12
+CAAUDIORK3X_SA_CopyFiles=12
 
 ;======================================================
 ; CAAUDIORK3X_SA
 ;======================================================
-[CAAUDIORK3X_SA.CopyList]
+[CAAUDIORK3X_SA_CopyFiles]
 csaudiork3x.sys
 
 [CAAUDIORK3X_SA.AddReg]
@@ -172,7 +172,7 @@ HKR,EP\0,%PKEY_AudioEndpoint_Supports_EventDriven_Mode%,0x00010001,0x1
 [CAAUDIORK3X_SA.NT]
 Include=ks.inf,wdmaudio.inf
 Needs=KS.Registration, WDMAUDIO.Registration
-CopyFiles=CAAUDIORK3X_SA.CopyList
+CopyFiles=CAAUDIORK3X_SA_CopyFiles
 AddReg=CAAUDIORK3X_SA.AddReg
 
 [CAAUDIORK3X_SA.NT.Interfaces]
@@ -229,7 +229,7 @@ DisplayName=%CsAudioRk3x.SvcDesc%
 ServiceType=1
 StartType=3
 ErrorControl=1
-ServiceBinary=%13%\csaudiork3x.sys
+ServiceBinary=%12%\csaudiork3x.sys
 
 [CAAUDIORK3X_SA.NT.HW]
 AddReg = AUDIOHW.AddReg

--- a/drivers/dma/pl330dma/insn.c
+++ b/drivers/dma/pl330dma/insn.c
@@ -161,26 +161,26 @@ static int _period(BOOLEAN dryRun, UINT8 buf[],
 	}
 
 	/* loop1 */
-	off += _emit_LP(dryRun, &buf[off], 1, lcnt1);
+	off += _emit_LP(dryRun, &buf[off], 1, (UINT8)lcnt1);
 	ljmp1 = off;
 	off += _bursts(dryRun, &buf[off], pxs, cyc);
 	lpend.cond = ALWAYS;
 	lpend.forever = FALSE;
 	lpend.loop = 1;
-	lpend.bjump = off - ljmp1;
+	lpend.bjump = (UINT8)(off - ljmp1);
 	off += _emit_LPEND(dryRun, &buf[off], &lpend);
 
 	/* remainder */
 	lcnt1 = bursts - (lcnt1 * cyc);
 
 	if (lcnt1) {
-		off += _emit_LP(dryRun, &buf[off], 1, lcnt1);
+		off += _emit_LP(dryRun, &buf[off], 1, (UINT8)lcnt1);
 		ljmp1 = off;
 		off += _bursts(dryRun, &buf[off], pxs, 1);
 		lpend.cond = ALWAYS;
 		lpend.forever = FALSE;
 		lpend.loop = 1;
-		lpend.bjump = off - ljmp1;
+		lpend.bjump = (UINT8)(off - ljmp1);
 		off += _emit_LPEND(dryRun, &buf[off], &lpend);
 	}
 
@@ -191,7 +191,7 @@ static int _period(BOOLEAN dryRun, UINT8 buf[],
 		off += _emit_MOV(dryRun, &buf[off], CCR, pxs->ccr);
 	}
 
-	off += _emit_SEV(dryRun, &buf[off], ev);
+	off += _emit_SEV(dryRun, &buf[off], (UINT8)ev);
 
 	return off;
 }
@@ -221,7 +221,7 @@ static int _loop_cyclic(BOOLEAN dryRun,
 	off += _emit_MOV(dryRun, &buf[off], DAR, pxs->dstAddr);
 
 	/* loop0 */
-	off += _emit_LP(dryRun, &buf[off], 0, lcnt0);
+	off += _emit_LP(dryRun, &buf[off], 0, (UINT8)lcnt0);
 	ljmp0 = off;
 
 	for (i = 0; i < periods; i++)
@@ -230,7 +230,7 @@ static int _loop_cyclic(BOOLEAN dryRun,
 	lpend.cond = ALWAYS;
 	lpend.forever = FALSE;
 	lpend.loop = 0;
-	lpend.bjump = off - ljmp0;
+	lpend.bjump = (UINT8)(off - ljmp0);
 	off += _emit_LPEND(dryRun, &buf[off], &lpend);
 
 	for (i = 0; i < residue; i++)
@@ -239,7 +239,7 @@ static int _loop_cyclic(BOOLEAN dryRun,
 	lpend.cond = ALWAYS;
 	lpend.forever = TRUE;
 	lpend.loop = 1;
-	lpend.bjump = off - ljmpfe;
+	lpend.bjump = (UINT8)(off - ljmpfe);
 	off += _emit_LPEND(dryRun, &buf[off], &lpend);
 
 	return off;
@@ -252,6 +252,7 @@ NTSTATUS SubmitAudioDMA(
 	UINT32 srcAddr, UINT32 dstAddr,
 	UINT32 len, UINT32 periodLen
 ) {
+    UNREFERENCED_PARAMETER(pDevice);
 	UINT32 ccr = fromDevice ? CC_DSTINC : CC_SRCINC;
 
 	ccr |= CC_SRCNS | CC_DSTNS;

--- a/drivers/dma/pl330dma/pl330.c
+++ b/drivers/dma/pl330dma/pl330.c
@@ -1,5 +1,4 @@
 #include "driver.h"
-#include "stdint.h"
 
 #define bool int
 #define MS_IN_US 1000
@@ -85,8 +84,8 @@ static NTSTATUS GetStringProperty(
 	inputBuffer->Section.Data3 = 0x4d8c;
 	memcpy(inputBuffer->Section.Data4, uuidend, sizeof(uuidend)); //Avoid Windows defender false positive
 
-	strcpy(inputBuffer->PropertyName, propertyStr);
-	inputBuffer->PropertyNameLength = strlen(propertyStr) + 1;
+	strcpy((CHAR*)inputBuffer->PropertyName, propertyStr);
+	inputBuffer->PropertyNameLength = (ULONG)strlen(propertyStr) + 1;
 
 	PACPI_EVAL_OUTPUT_BUFFER outputBuffer;
 	size_t outputBufferSize = FIELD_OFFSET(ACPI_EVAL_OUTPUT_BUFFER, Argument) + sizeof(ACPI_METHOD_ARGUMENT_V1) + propertyLen;

--- a/drivers/gpio/rk3xgpio/rk3xgpio.vcxproj
+++ b/drivers/gpio/rk3xgpio/rk3xgpio.vcxproj
@@ -98,16 +98,10 @@
     <ResourceCompile Include="rk3xgpio.rc" />
   </ItemGroup>
   <ItemGroup>
-    <Inf Exclude="@(Inf)" Include="*.inf" />
     <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
   </ItemGroup>
   <ItemGroup>
-    <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
-    <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
-    <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
+    <Text Include="LICENSE.txt" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/drivers/i2c/rk3xi2c/rk3xi2c.c
+++ b/drivers/i2c/rk3xi2c/rk3xi2c.c
@@ -1,5 +1,4 @@
 #include "driver.h"
-#include "stdint.h"
 
 #define bool int
 #define MS_IN_US 1000
@@ -58,7 +57,7 @@ static NTSTATUS GetIntegerProperty(
 	char* propertyStr,
 	UINT32* property
 ) {
-	PRK3XI2C_CONTEXT pDevice = GetDeviceContext(FxDevice);
+	//PRK3XI2C_CONTEXT pDevice = GetDeviceContext(FxDevice);
 	WDFMEMORY outputMemory = WDF_NO_HANDLE;
 
 	NTSTATUS status = STATUS_ACPI_NOT_INITIALIZED;
@@ -79,8 +78,8 @@ static NTSTATUS GetIntegerProperty(
 	inputBuffer->Section.Data3 = 0x4d8c;
 	memcpy(inputBuffer->Section.Data4, uuidend, sizeof(uuidend)); //Avoid Windows defender false positive
 
-	strcpy(inputBuffer->PropertyName, propertyStr);
-	inputBuffer->PropertyNameLength = strlen(propertyStr) + 1;
+	strcpy((CHAR*)inputBuffer->PropertyName, propertyStr);
+	inputBuffer->PropertyNameLength = (ULONG)strlen(propertyStr) + 1;
 
 	PACPI_EVAL_OUTPUT_BUFFER outputBuffer;
 	size_t outputArgumentBufferSize = 8;
@@ -287,6 +286,7 @@ Status
 	PRK3XI2C_CONTEXT pDevice = GetDeviceContext(FxDevice);
 
 	UINT32 version = (read32(pDevice, REG_CON) & (0xff << 16)) >> 16;
+    UNREFERENCED_PARAMETER(version);
 	Rk3xI2CPrint(DEBUG_LEVEL_INFO, DBG_INIT,
 		"Version: %d\n", version);
 
@@ -315,6 +315,7 @@ Status
 
 --*/
 {
+    UNREFERENCED_PARAMETER(FxDevice);
 	UNREFERENCED_PARAMETER(FxTargetState);
 
 	NTSTATUS status = STATUS_SUCCESS;
@@ -379,6 +380,7 @@ VOID OnSpbIoRead(
 	_In_ size_t Length
 )
 {
+    UNREFERENCED_PARAMETER(Length);
 	PRK3XI2C_CONTEXT pDevice = GetDeviceContext(SpbController);
 
 	NTSTATUS status = i2c_xfer(pDevice, SpbTarget, SpbRequest, 1);
@@ -392,6 +394,7 @@ VOID OnSpbIoWrite(
 	_In_ size_t Length
 )
 {
+    UNREFERENCED_PARAMETER(Length);
 	PRK3XI2C_CONTEXT pDevice = GetDeviceContext(SpbController);
 
 	NTSTATUS status = i2c_xfer(pDevice, SpbTarget, SpbRequest, 1);

--- a/drivers/i2c/rk3xi2c/rockchipi2c.c
+++ b/drivers/i2c/rk3xi2c/rockchipi2c.c
@@ -74,7 +74,7 @@ static void rk3x_i2c_stop(PRK3XI2C_CONTEXT pDevice, NTSTATUS status)
  */
 static void rk3x_i2c_prepare_read(PRK3XI2C_CONTEXT pDevice)
 {
-	unsigned int len = pDevice->currentDescriptor.TransferLength - pDevice->processed;
+	size_t len = pDevice->currentDescriptor.TransferLength - pDevice->processed;
 	UINT32 con;
 
 	con = read32(pDevice, REG_CON);
@@ -98,7 +98,7 @@ static void rk3x_i2c_prepare_read(PRK3XI2C_CONTEXT pDevice)
 	}
 
 	write32(pDevice, REG_CON, con);
-	write32(pDevice, REG_MRXCNT, len);
+	write32(pDevice, REG_MRXCNT, (UINT32)len);
 }
 
 /**
@@ -197,7 +197,7 @@ static void rk3x_i2c_handle_write(PRK3XI2C_CONTEXT pDevice, unsigned int ipd)
 static void rk3x_i2c_handle_read(PRK3XI2C_CONTEXT pDevice, unsigned int ipd)
 {
 	unsigned int i;
-	unsigned int len = pDevice->currentDescriptor.TransferLength - pDevice->processed;
+	size_t len = pDevice->currentDescriptor.TransferLength - pDevice->processed;
 	UINT32 val = 0;
 	UINT8 byte;
 
@@ -385,7 +385,7 @@ NTSTATUS i2c_xfer_single(
 	pDevice->currentMDLChain = mdlChain;
 
 	pDevice->isLastMsg = FALSE;
-	pDevice->I2CAddress = pTarget->Settings.Address;
+	pDevice->I2CAddress = (UINT8)pTarget->Settings.Address;
 	pDevice->isBusy = TRUE;
 	pDevice->state = STATE_START;
 	pDevice->processed = 0;
@@ -435,7 +435,7 @@ NTSTATUS i2c_xfer(PRK3XI2C_CONTEXT pDevice,
 	rk3x_i2c_adapt_div(pDevice, pDevice->baseClock);
 
 	SPB_TRANSFER_DESCRIPTOR descriptor;
-	for (int i = 0; i < TransferCount; i++) {
+	for (ULONG i = 0; i < TransferCount; i++) {
 		PMDL mdlChain;
 
 		SPB_TRANSFER_DESCRIPTOR_INIT(&descriptor);
@@ -448,8 +448,8 @@ NTSTATUS i2c_xfer(PRK3XI2C_CONTEXT pDevice,
 		if (!NT_SUCCESS(status))
 			break;
 
-		transferredLength += descriptor.TransferLength;
-		WdfRequestSetInformation(SpbRequest, transferredLength);
+		transferredLength += (UINT32)descriptor.TransferLength;
+		WdfRequestSetInformation((WDFREQUEST)SpbRequest, transferredLength);
 	}
 
 	WdfWaitLockRelease(pDevice->waitLock);

--- a/drivers/sd/dwcsdhc/dwcsdhc.vcxproj
+++ b/drivers/sd/dwcsdhc/dwcsdhc.vcxproj
@@ -77,22 +77,17 @@
     <ResourceCompile Include="dwcsdhc.rc" />
   </ItemGroup>
   <ItemGroup>
-    <Inf Exclude="@(Inf)" Include="*.inf" />
     <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
     <Inf Include="dwcsdhc.inx" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
-    <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
-    <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\rk_sip_sdmmc_lib\rk_sip_sdmmc_lib.vcxproj">
       <Project>{3f0e7d7d-bb1e-42f9-841f-75204a447cc6}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="dwcsdhc.h" />
+    <ClInclude Include="precomp.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
Fix a bunch of build warnings.

- GitHub actions were failing due to use of V3 artifacts upload.
- ServiceBinary `%12%\csaudiork3x.sys` does not have a corresponding
  CopyFiles. Fix by changing `CopyFiles=13` to `CopyFiles=12` to match
  the ServiceBinary entry. (Also rename CopyList to CopyFiles for
  consistency.)
- Wildcards should not be used in vcxproj files. Fix by expanding
  wildcards.
- Various issues with macro conflicts caused by
  `#include  <stdint.h>`. stdint.h is a great header, but the Windows
  SDK only provides a user-mode version of it, and that version causes
  conflicts with the kernel-mode headers. Fix by removing references to
  stdint.h and using `UINT8` as needed.
- Various warnings about missing casts. Added casts or modified variable
  types as seemed appropriate.